### PR TITLE
Update copyright stanzas to match Sigstore.

### DIFF
--- a/model_signing/main.py
+++ b/model_signing/main.py
@@ -1,4 +1,4 @@
-# Copyright Google LLC
+# Copyright 2024 The Sigstore Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/model_signing/model.py
+++ b/model_signing/model.py
@@ -1,4 +1,4 @@
-# Copyright Google LLC
+# Copyright 2024 The Sigstore Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/model_signing/serialize.py
+++ b/model_signing/serialize.py
@@ -1,4 +1,4 @@
-# Copyright Google LLC
+# Copyright 2024 The Sigstore Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/slsa_for_models/main.py
+++ b/slsa_for_models/main.py
@@ -1,4 +1,4 @@
-# Copyright Google LLC
+# Copyright 2024 The Sigstore Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/slsa_for_models/pytorch_cifar10.py
+++ b/slsa_for_models/pytorch_cifar10.py
@@ -1,4 +1,4 @@
-# Copyright Google LLC
+# Copyright 2024 The Sigstore Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/slsa_for_models/tensorflow_cifar10.py
+++ b/slsa_for_models/tensorflow_cifar10.py
@@ -1,4 +1,4 @@
-# Copyright Google LLC
+# Copyright 2024 The Sigstore Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
#### Summary
Updating the copyright stanzas to match sigstore. This should have been done after we migrated the repo, but I forgot.

#### Release Note
NONE

#### Documentation
NONE