### PR TITLE
updating docs to use the sigstore repo instead of google

### DIFF
--- a/model_signing/README.md
+++ b/model_signing/README.md
@@ -35,7 +35,7 @@ After this, you can clone the repository, create a Python virtual environment
 and install the dependencies needed by the project:
 
 ```bash
-git clone git@github.com:google/model-transparency.git
+git clone git@github.com:sigstore/model-transparency.git
 cd model-transparency/model_signing
 python3 -m venv test_env
 source test_env/bin/activate
@@ -182,7 +182,7 @@ Ensure you have enough disk space:
 To run the benchmarks:
 
 ```bash
-git clone git@github.com:google/model-transparency.git
+git clone git@github.com:sigstore/model-transparency.git
 cd model-transparency/model_signing
 bash benchmarks/run.sh https://accounts.google.com myemail@gmail.com [true]
 ```

--- a/slsa_for_models/README.md
+++ b/slsa_for_models/README.md
@@ -65,6 +65,6 @@ SLSA (in general, not just for ML).
 [solarwinds]: https://www.techtarget.com/whatis/feature/SolarWinds-hack-explained-Everything-you-need-to-know
 [tekton-chains]: https://github.com/tektoncd/chains
 [tekton-kubeflow]: https://www.kubeflow.org/docs/components/pipelines/v1/sdk/pipelines-with-tekton/
-[workflow]: https://github.com/google/model-transparency/blob/main/.github/workflows/slsa_for_ml.yml
+[workflow]: https://github.com/sigstore/model-transparency/blob/main/.github/workflows/slsa_for_ml.yml
 [gha]: github_actions.md
 [gcp]: gcp

--- a/slsa_for_models/gcp/pipeline.yml
+++ b/slsa_for_models/gcp/pipeline.yml
@@ -20,7 +20,7 @@ spec:
         requirements-path: {}
         main-path: {}
       default:
-        url: 'https://github.com/google/model-transparency'
+        url: 'https://github.com/sigstore/model-transparency'
         revision: 'main'
         requirements-path: 'slsa_for_models/install/requirements_Linux.txt'
         main-path: 'slsa_for_models/main.py'
@@ -56,7 +56,7 @@ spec:
         resolver: git
         params:
         - name: url
-          value: https://github.com/google/model-transparency.git
+          value: https://github.com/sigstore/model-transparency.git
         - name: revision
           value: $(params.model-source.revision)
         - name: pathInRepo
@@ -80,7 +80,7 @@ spec:
         resolver: git
         params:
         - name: url
-          value: https://github.com/google/model-transparency.git
+          value: https://github.com/sigstore/model-transparency.git
         - name: revision
           value: $(params.model-source.revision)
         - name: pathInRepo
@@ -105,7 +105,7 @@ spec:
         resolver: git
         params:
         - name: url
-          value: https://github.com/google/model-transparency.git
+          value: https://github.com/sigstore/model-transparency.git
         - name: revision
           value: $(params.model-source.revision)
         - name: pathInRepo

--- a/slsa_for_models/github_actions.md
+++ b/slsa_for_models/github_actions.md
@@ -34,12 +34,12 @@ SLSA provenance attached to the model.
 To verify the provenance, download both archives, unzip each and then run
 `slsa-verifier`, making sure to replace the `--source-uri` argument with the
 _path to your fork_. For example, for a PyTorch model, which has been [built on
-this repository](https://github.com/google/model-transparency/actions/runs/6646816974):
+this repository](https://github.com/sigstore/model-transparency/actions/runs/6646816974):
 
 ```bash
 [...]$ slsa-verifier verify-artifact \
        --provenance-path pytorch_model.pth.intoto.jsonl \
-       --source-uri github.com/google/model-transparency \
+       --source-uri github.com/sigstore/model-transparency \
        pytorch_model.pth
 Verified signature against tlog entry index 45419124 at URL: https://rekor.sigstore.dev/api/v1/log/entries/24296fb24b8ad77a98dd03d23a78657e7f1efd3d9bea6988abbf23a72290a4ec7dc35c9edeab7ee1
 Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.9.0" at commit ac26cbf66849cfec6f29747f4525180595c7eef0
@@ -58,4 +58,4 @@ the serving pipeline.
 [solarwinds]: https://www.techtarget.com/whatis/feature/SolarWinds-hack-explained-Everything-you-need-to-know
 [tekton-chains]: https://github.com/tektoncd/chains
 [tekton-kubeflow]: https://www.kubeflow.org/docs/components/pipelines/v1/sdk/pipelines-with-tekton/
-[workflow]: https://github.com/google/model-transparency/blob/main/.github/workflows/slsa_for_ml.yml
+[workflow]: https://github.com/sigstore/model-transparency/blob/main/.github/workflows/slsa_for_ml.yml

--- a/slsa_for_models/kubeflow/model_transparency.py
+++ b/slsa_for_models/kubeflow/model_transparency.py
@@ -105,7 +105,7 @@ def upload_model(location: str, source: str, workDir: str):
     description="Clone the source code, build & upload the model to GCS.",
 )
 def clone_build_push(
-    url: str = "https://github.com/google/model-transparency",
+    url: str = "https://github.com/sigstore/model-transparency",
     target: str = "source",
     model: str = "pytorch_model.pth",
 ):


### PR DESCRIPTION
Partially addresses: #179 . My only question is if we should swap the remote protocol from `ssh` based remote to `https` as the docs only imply running code rather than contributing to the codebase.

#### Summary

Updating documentation while onboarding to project.

#### Release Note

None

#### Documentation

No documentation, nothing exists in the official docs regarding model signing at this point.

