### PR TITLE
Show the federated IdP in the CLI instead of the Sigstore DEX instance

### DIFF
--- a/model_signing/model.py
+++ b/model_signing/model.py
@@ -101,7 +101,10 @@ class SigstoreSigner():
             oidc_token = self.get_identity_token()
             if not oidc_token:
                 raise ValueError("No identity token supplied or detected!")
-            print(f"identity-provider: {oidc_token.issuer}",
+            # Calling the private attribute IdentityToken._federated issuer
+            # is a workaround for earlier versions of sigstore-python (<3.0.0)
+            # that do not support the federated_issuer property.
+            print(f"identity-provider: {oidc_token._federated_issuer}",
                   file=sys.stderr)
             print(f"identity: {oidc_token.identity}", file=sys.stderr)
 


### PR DESCRIPTION
Resolves #157

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Show the federated IdP instead of the Sigstore DEX instance, extracted from `sigstore.oidc.IdentityToken`.
As mentioned in the comment, this is more of a workaround for versions of `sigstore-python` earlier than `3.0.0`, as the `federated_issuer` property could be called directly in the latest version.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Replaced DEX instance with federated IdP in signing CLI field `identity-provider`.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
No documentation required.
