### PR TITLE
Chore: Test for missing endline at eof, fix lint errors.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,14 +27,12 @@ jobs:
           set -euxo pipefail  # No -x here!
           failed=0
           # First, check for empty files at end
-          for file in $(git ls-files --eol | grep 'i/[cr]*lf' | awk '{print $4}'); do
-            lines=$(tac "$file" | awk 'NF{exit};END{print NR?NR-1:0}')
-            if [[ $lines -ne 0 ]]; then
-              line=$(wc -l "$file" | cut -d' ' -f1)
-              echo "::error file=$file,line=$line::File $file has $lines empty lines at end. Please remove."
-              failed=$((failed + 1))
-            fi
+          for file in $(for f in $(git ls-files --eol | grep 'i/[cr]*lf' | awk '{print $4}'); do egrep -l "^$" $file; done); do
+            line=$(wc -l "$file" | cut -d ' ' -f1)
+            echo "::error file=$file,line=$line::File $file has empty lines at end. Please remove."
+            failed=$((failed + 1))
           done
+
           # Next, check for files with whitespace at end of line. Remove CRLF files.
           for file in $(git ls-files --eol | grep 'i/lf' | awk '{print $4}'); do
             for line in $(grep -n '[[:space:]]$' "$file" | cut -d: -f1); do
@@ -42,6 +40,17 @@ jobs:
               failed=$((failed + 1))
             done
           done
+
+          # Finally, check for missing endline at end of file, for any text file.
+          for file in $(git ls-files | grep 'i/lf' | awk '{print $4}'); do
+            if [[ -n "$(tail -c 1 "$file")" ]]; then
+              line=$(wc -l "$file" | cut -d ' ' -f1)
+              echo "::error file=$file,line=$line::File $file needs an endline at the end. Please add."
+              failed=$((failed + 1))
+            fi
+          done
+
+          # Report status
           if [[ $failed -ne 0 ]]; then
             echo "::error Found $failed whitespace errors, failing"
             exit 1


### PR DESCRIPTION
#### Summary
We were missing a test that all text files end with a newline character (found in #193).

Also, the old `tac | awk` process to count the number of empty lines at the end of a file was prone to failures if `awk` exits early (found in #198). So I replaced it with a test that should be more resilient.

#### Release Note
NONE

#### Documentation
NONE