### PR TITLE
Prepare for manifest

### DIFF
--- a/model_signing/manifest/manifest.py
+++ b/model_signing/manifest/manifest.py
@@ -32,7 +32,7 @@ class Manifest(metaclass=abc.ABCMeta):
     pass
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class DigestManifest(Manifest):
     """A manifest that is just a hash."""
 

--- a/model_signing/serialization/dfs.py
+++ b/model_signing/serialization/dfs.py
@@ -140,7 +140,7 @@ class DFSSerializer(serialization.Serializer):
         return hasher.compute()
 
 
-def _endpoints(step: int, end: int) -> Iterable[int]:
+def endpoints(step: int, end: int) -> Iterable[int]:
     """Yields numbers from `step` to `end` inclusive, spaced by `step`.
 
     Last value is always equal to `end`, even when `end` is not a multiple of
@@ -148,11 +148,11 @@ def _endpoints(step: int, end: int) -> Iterable[int]:
 
     Examples:
     ```python
-    >>> list(_endpoints(2, 8))
+    >>> list(endpoints(2, 8))
     [2, 4, 6, 8]
-    >>> list(_endpoints(2, 9))
+    >>> list(endpoints(2, 9))
     [2, 4, 6, 8, 9]
-    >>> list(_endpoints(2, 2))
+    >>> list(endpoints(2, 2))
     [2]
 
     Yields:
@@ -281,7 +281,7 @@ class ShardedDFSSerializer(serialization.Serializer):
             if path.is_file():
                 path_size = path.stat().st_size
                 start = 0
-                for end in _endpoints(self._shard_size, path_size):
+                for end in endpoints(self._shard_size, path_size):
                     tasks.append((relative_path, "file", start, end))
                     start = end
             else:

--- a/model_signing/serialization/dfs.py
+++ b/model_signing/serialization/dfs.py
@@ -64,6 +64,13 @@ def _build_header(
     Args:
         entry_name: The name of the entry to build the header for.
         entry_type: The type of the entry (file or directory).
+        start: Optional offset for the start of the path shard.
+        end: Optional offset for the end of the path shard.
+
+    Returns:
+        A sequence of bytes that encodes all arguments as a sequence of UTF-8
+        bytes. Each argument is separated by dots and the last byte is also a
+        dot (so the file digest can be appended unambiguously).
     """
     encoded_type = entry_type.encode("utf-8")
     # Prevent confusion if name has a "." inside by encoding to base64.

--- a/model_signing/serialization/dfs.py
+++ b/model_signing/serialization/dfs.py
@@ -26,6 +26,9 @@ from model_signing.manifest import manifest
 from model_signing.serialization import serialization
 
 
+_ShardSignTask: TypeAlias = tuple[pathlib.PurePath, str, int, int]
+
+
 def _check_file_or_directory(path: pathlib.Path) -> bool:
     """Checks that the given path is either a file or a directory.
 
@@ -129,10 +132,6 @@ class DFSSerializer(serialization.Serializer):
                 hasher.update(digest.digest_value)
 
         return hasher.compute()
-
-
-# Define type aliases for the ShardedDFSSerializer class below.
-_ShardSignTask: TypeAlias = tuple[pathlib.PurePath, str, int, int]
 
 
 def _endpoints(step: int, end: int) -> Iterable[int]:

--- a/model_signing/serialization/dfs_test.py
+++ b/model_signing/serialization/dfs_test.py
@@ -574,3 +574,20 @@ class TestShardedDFSSerializer:
             ValueError, match="Cannot use .* as file or directory"
         ):
             serializer.serialize(pipe)
+
+
+class TestUtilities:
+
+    def test_check_file_or_directory_raises_on_pipes(self, sample_model_file):
+        pipe = sample_model_file.with_name("pipe")
+
+        try:
+            os.mkfifo(pipe)
+        except AttributeError:
+            # On Windows, `os.mkfifo` does not exist (it should not).
+            return  # trivially pass the test
+
+        with pytest.raises(
+            ValueError, match="Cannot use .* as file or directory"
+        ):
+            dfs.check_file_or_directory(pipe)

--- a/model_signing/serialization/dfs_test.py
+++ b/model_signing/serialization/dfs_test.py
@@ -591,3 +591,12 @@ class TestUtilities:
             ValueError, match="Cannot use .* as file or directory"
         ):
             dfs.check_file_or_directory(pipe)
+
+    def test_endpoints_exact(self):
+        assert list(dfs.endpoints(2, 8)) == [2, 4, 6, 8]
+
+    def test_endpoints_extra(self):
+        assert list(dfs.endpoints(2, 9)) == [2, 4, 6, 8, 9]
+
+    def test_endpoints_equal(self):
+        assert list(dfs.endpoints(2, 2)) == [2]


### PR DESCRIPTION
#### Summary
The important part of the PR is the exporting of `_endpoints` and `_check_file_or_directory` as I'm using them to build the manifest that contains every file digest instead of just one single digest.

While doing these transformations, I also cleaned some typos, made comments be correct instead of copy-pasted from other places. Made sure docstrings document all the arguments and yield/return types. Changed TODOs to fully link to the GitHub issue instead of just the number. And refactored 2 functions names to be clearer on their purpose (per internal review).

This is on top of #218, since I needed some changes in the test setup too. But I separated the test changes to a separate PR to make it easier to review. Speaking of, each commit here can also be reviewed individually.

#### Release Note
NONE

#### Documentation
NONE