### PR TITLE
Add initial support for itemized model manifests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,4 +85,4 @@ jobs:
           pip install -r model_signing/install/requirements_dev_Linux.txt
           # TODO: https://github.com/sigstore/model-transparency/issues/231 - Support all repo
           # We should actually migrate to ruff, but that's configured via pyproject.toml which we use when we release the wheel
-          pylint --disable C0114,C0115,C0116,R0903,R0904,R0913,R0914,R1721,R1737,W0107,W0223,W0231,W0511,W0621 model_signing/{hashing,manifest,serialization}
+          pylint --disable C0114,C0115,C0116,R0801,R0903,R0904,R0913,R0914,R1721,R1737,W0107,W0223,W0231,W0511,W0621 model_signing/{hashing,manifest,serialization}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,4 +85,4 @@ jobs:
           pip install -r model_signing/install/requirements_dev_Linux.txt
           # TODO: https://github.com/sigstore/model-transparency/issues/231 - Support all repo
           # We should actually migrate to ruff, but that's configured via pyproject.toml which we use when we release the wheel
-          pylint --disable C0114,C0115,C0116,R0801,R0903,R0904,R0913,R0914,R1721,R1737,W0107,W0223,W0231,W0511,W0621 model_signing/{hashing,manifest,serialization}
+          pylint --disable C0114,C0115,C0116,R0801,R0903,R0904,R0913,R0914,R1721,R1737,W0107,W0212,W0223,W0231,W0511,W0621 model_signing/{hashing,manifest,serialization}

--- a/model_signing/manifest/manifest.py
+++ b/model_signing/manifest/manifest.py
@@ -25,7 +25,7 @@ could be a signature over a single digest).
 When testing the integrity of a model, we start with the model path and model
 type. From this, we extract the path to the signed manifest. Next step is to
 verify the authenticity of the signature, after which we extract an in-memory
-representation of the _trusted_ manifest. To verify the model in its integrity,
+representation of the _trusted_ manifest. To verify the integrity of the model,
 we run another `serialization.Serializer` instance to compute the _untrusted_
 manifest of the model as we're seeing it. If these 2 manifests are conforming,
 then the model integrity is maintained.

--- a/model_signing/manifest/manifest.py
+++ b/model_signing/manifest/manifest.py
@@ -28,7 +28,7 @@ manifest of the model as we're seeing it. If these two manifests agree then the
 model integrity is maintained.
 
 In the simplest case, we are working with `DigestManifest` objects. Here, the
-two manifests are conforming iff the digests are the same. A more complex case
+two manifests agree if and only if the digests are the same. A more complex case
 is when the manifest itemizes each model component (e.g., every file (or file
 shard) is paired with its digest). The manifests agree if every file and digest
 matches. Alternatively, we could allow for file renames, and check only the

--- a/model_signing/manifest/manifest.py
+++ b/model_signing/manifest/manifest.py
@@ -96,7 +96,7 @@ class ManifestItem(metaclass=abc.ABCMeta):
     pass
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class FileManifestItem(ManifestItem):
     """A manifest item that records a filename path together with its digest.
 
@@ -105,6 +105,17 @@ class FileManifestItem(ManifestItem):
 
     path: pathlib.PurePath
     digest: hashing.Digest
+
+    def __init__(self, *, path: pathlib.PurePath, digest: hashing.Digest):
+        """Builds a manifest item pairing a file with its digest.
+
+        Args:
+            path: The path to the file, relative to the model root.
+            digest: The digest of the file.
+        """
+        # Note: we need to force a PosixPath to canonicalize the manifest
+        self.path = pathlib.PurePosixPath(path)
+        self.digest = digest
 
 
 class FileLevelManifest(ItemizedManifest):
@@ -122,7 +133,7 @@ class FileLevelManifest(ItemizedManifest):
         return self._digest_info == other._digest_info
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class ShardedFileManifestItem(ManifestItem):
     """A manifest item that records a file shard together with its digest."""
 
@@ -130,6 +141,28 @@ class ShardedFileManifestItem(ManifestItem):
     start: int
     end: int
     digest: hashing.Digest
+
+    def __init__(
+        self,
+        *,
+        path: pathlib.PurePath,
+        start: int,
+        end: int,
+        digest: hashing.Digest
+    ):
+        """Builds a manifest item pairing a file with its digest.
+
+        Args:
+            path: The path to the file, relative to the model root.
+            start: The start offset of the shard.
+            end: The end offset of the shard.
+            digest: The digest of the file.
+        """
+        # Note: we need to force a PosixPath to canonicalize the manifest
+        self.path = pathlib.PurePosixPath(path)
+        self.start = start
+        self.end = end
+        self.digest = digest
 
     @property
     def input_tuple(self) -> tuple[pathlib.PurePath, int, int]:

--- a/model_signing/manifest/manifest.py
+++ b/model_signing/manifest/manifest.py
@@ -16,31 +16,28 @@
 
 When saving a model, or signing an existing one, we build a manifest from the
 model (either by using a `serialization.Serializer` or building it from helper
-methods that use precomputed values to reduce amount of I/O involved). This
-manifest then gets signed and the signed manifest (or just signature) is stored
-in a signature file determined from the model path and type. The signature is
-loosely tied with the manifest (e.g., it could be a field in the manifest or it
-could be a signature over a single digest).
+methods that use precomputed values to reduce amount of I/O involved). This is
+the manifest used for generating a signature of the model.
 
 When testing the integrity of a model, we start with the model path and model
 type. From this, we extract the path to the signed manifest. Next step is to
 verify the authenticity of the signature, after which we extract an in-memory
-representation of the _trusted_ manifest. To verify the integrity of the model,
-we run another `serialization.Serializer` instance to compute the _untrusted_
-manifest of the model as we're seeing it. If these 2 manifests are conforming,
-then the model integrity is maintained.
+representation of the _expected_ manifest. To verify the integrity of the model,
+we run another `serialization.Serializer` instance to compute the _actual_
+manifest of the model as we're seeing it. If these two manifests agree then the
+model integrity is maintained.
 
 In the simplest case, we are working with `DigestManifest` objects. Here, the
 two manifests are conforming iff the digests are the same. A more complex case
 is when the manifest itemizes each model component (e.g., every file (or file
-shard) is paired with its digest). The manifests would be conforming if every
-file and digest matches. Alternatively, we could allow for file renames, and
-check only the digests. Optionally, we can have arbitrary logic, saying that the
-untrusted manifest must match only a subset of the trusted one: e.g., we could
-have a model saved in multiple formats but with a single signature. At
-verification time, only one format is used, so we only need to verify the
-corresponding subset. We need to check that we still have a valid complete model
-though.
+shard) is paired with its digest). The manifests agree if every file and digest
+matches. Alternatively, we could allow for file renames, and check only the
+digests. Optionally, we can have arbitrary logic, saying that the actual
+manifest (i.e., files of the model as they are on disk) must match only a subset
+of the expected one: e.g., we could have a model saved in multiple formats but
+with a single signature. At verification time, only one format is used, so we
+only need to verify the corresponding subset. We need to check that we still
+have a valid complete model though.
 
 In the future, we envision an API that would allow verification to be done in a
 streaming fashion. As the model is loaded for inference, only the integrity of

--- a/model_signing/manifest/manifest.py
+++ b/model_signing/manifest/manifest.py
@@ -152,8 +152,8 @@ class ShardedFileManifestItem(ManifestItem):
 
         Args:
             path: The path to the file, relative to the model root.
-            start: The start offset of the shard.
-            end: The end offset of the shard.
+            start: The start offset of the shard (included).
+            end: The end offset of the shard (not included).
             digest: The digest of the file shard.
         """
         # Note: we need to force a PosixPath to canonicalize the manifest

--- a/model_signing/manifest/manifest.py
+++ b/model_signing/manifest/manifest.py
@@ -55,9 +55,10 @@ objects to represent only a part of the model that can be verified individually.
 """
 
 import abc
+from collections.abc import Iterable
 import dataclasses
 import pathlib
-from typing import Iterable, Self
+from typing import Self
 
 from model_signing.hashing import hashing
 
@@ -113,7 +114,7 @@ class FileManifestItem(ManifestItem):
             path: The path to the file, relative to the model root.
             digest: The digest of the file.
         """
-        # Note: we need to force a PosixPath to canonicalize the manifest
+        # Note: we need to force a PosixPath to canonicalize the manifest.
         self.path = pathlib.PurePosixPath(path)
         self.digest = digest
 
@@ -127,10 +128,10 @@ class FileLevelManifest(ItemizedManifest):
         Rather than recording the items in a list, we use a dictionary, to allow
         efficient updates and retrieval of digests.
         """
-        self._digest_info = {item.path: item.digest for item in items}
+        self._item_to_digest = {item.path: item.digest for item in items}
 
     def __eq__(self, other: Self):
-        return self._digest_info == other._digest_info
+        return self._item_to_digest == other._item_to_digest
 
 
 @dataclasses.dataclass
@@ -170,7 +171,7 @@ class ShardedFileManifestItem(ManifestItem):
         return (self.path, self.start, self.end)
 
 
-class ShardLevelManifest(ItemizedManifest):
+class ShardLevelManifest(FileLevelManifest):
     """A detailed manifest, recording integrity of every model file."""
 
     def __init__(self, items: Iterable[ShardedFileManifestItem]):
@@ -179,7 +180,4 @@ class ShardLevelManifest(ItemizedManifest):
         Rather than recording the items in a list, we use a dictionary, to allow
         efficient updates and retrieval of digests.
         """
-        self._digest_info = {item.input_tuple: item.digest for item in items}
-
-    def __eq__(self, other: Self):
-        return self._digest_info == other._digest_info
+        self._item_to_digest = {item.input_tuple: item.digest for item in items}

--- a/model_signing/manifest/manifest.py
+++ b/model_signing/manifest/manifest.py
@@ -150,13 +150,13 @@ class ShardedFileManifestItem(ManifestItem):
         end: int,
         digest: hashing.Digest
     ):
-        """Builds a manifest item pairing a file with its digest.
+        """Builds a manifest item pairing a file shard with its digest.
 
         Args:
             path: The path to the file, relative to the model root.
             start: The start offset of the shard.
             end: The end offset of the shard.
-            digest: The digest of the file.
+            digest: The digest of the file shard.
         """
         # Note: we need to force a PosixPath to canonicalize the manifest
         self.path = pathlib.PurePosixPath(path)

--- a/model_signing/manifest/manifest.py
+++ b/model_signing/manifest/manifest.py
@@ -14,14 +14,50 @@
 
 """Machinery for representing a serialized representation of an ML model.
 
-Currently, we only support a manifest that wraps around a digest. But, to
-support incremental updates and partial signature verification, we need a
-manifest that lists files and their digests. That will come in a future change,
-soon.
+When saving a model, or signing an existing one, we build a manifest from the
+model (either by using a `serialization.Serializer` or building it from helper
+methods that use precomputed values to reduce amount of I/O involved). This
+manifest then gets signed and the signed manifest (or just signature) is stored
+in a signature file determined from the model path and type. The signature is
+loosely tied with the manifest (e.g., it could be a field in the manifest or it
+could be a signature over a single digest).
+
+When testing the integrity of a model, we start with the model path and model
+type. From this, we extract the path to the signed manifest. Next step is to
+verify the authenticity of the signature, after which we extract an in-memory
+representation of the _trusted_ manifest. To verify the model in its integrity,
+we run another `serialization.Serializer` instance to compute the _untrusted_
+manifest of the model as we're seeing it. If these 2 manifests are conforming,
+then the model integrity is maintained.
+
+In the simplest case, we are working with `DigestManifest` objects. Here, the
+two manifests are conforming iff the digests are the same. A more complex case
+is when the manifest itemizes each model component (e.g., every file (or file
+shard) is paired with its digest). The manifests would be conforming if every
+file and digest matches. Alternatively, we could allow for file renames, and
+check only the digests. Optionally, we can have arbitrary logic, saying that the
+untrusted manifest must match only a subset of the trusted one: e.g., we could
+have a model saved in multiple formats but with a single signature. At
+verification time, only one format is used, so we only need to verify the
+corresponding subset. We need to check that we still have a valid complete model
+though.
+
+In the future, we envision an API that would allow verification to be done in a
+streaming fashion. As the model is loaded for inference, only the integrity of
+the part that gets loaded would be verified, to not penalize inference hosts
+when only a tiny subset of a large model is used. This also means that we can
+add support for updating a manifest in a streaming fashion while a model is
+trained (or post-training to update ancillary files -- requires re-signing).
+
+All these alternative scenarios will be implemented by various subclasses of the
+`Manifest` class defined here. Itemized manifests make use of `ItemizedManifest`
+objects to represent only a part of the model that can be verified individually.
 """
 
 import abc
 import dataclasses
+import pathlib
+from typing import Iterable, Self
 
 from model_signing.hashing import hashing
 
@@ -37,3 +73,80 @@ class DigestManifest(Manifest):
     """A manifest that is just a hash."""
 
     digest: hashing.Digest
+
+
+class ItemizedManifest(Manifest):
+    """A detailed manifest, recording integrity of every model component."""
+
+    pass
+
+
+class ManifestItem(metaclass=abc.ABCMeta):
+    """An object of a model that can be stored in an `ItemizedManifest`.
+
+    For example, this could be a file, or a file shard. All file paths are
+    relative to the model root, to allow moving or renaming the model, without
+    invalidating the signature.
+
+    The integrity of each `ManifestItem` can be verified individually and in
+    parallel. If the item is backed by a file, we recompute the hash of the
+    portion of the file that represents this item.
+    """
+
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class FileManifestItem(ManifestItem):
+    """A manifest item that records a filename path together with its digest.
+
+    Note that the path component is a `pathlib.PurePath`, relative to the model.
+    """
+
+    path: pathlib.PurePath
+    digest: hashing.Digest
+
+
+class FileLevelManifest(ItemizedManifest):
+    """A detailed manifest, recording integrity of every model file."""
+
+    def __init__(self, items: Iterable[FileManifestItem]):
+        """Builds an itemized manifest from a collection of files.
+
+        Rather than recording the items in a list, we use a dictionary, to allow
+        efficient updates and retrieval of digests.
+        """
+        self._digest_info = {item.path: item.digest for item in items}
+
+    def __eq__(self, other: Self):
+        return self._digest_info == other._digest_info
+
+
+@dataclasses.dataclass(frozen=True)
+class ShardedFileManifestItem(ManifestItem):
+    """A manifest item that records a file shard together with its digest."""
+
+    path: pathlib.PurePath
+    start: int
+    end: int
+    digest: hashing.Digest
+
+    @property
+    def input_tuple(self) -> tuple[pathlib.PurePath, int, int]:
+        """Returns the triple that uniquely determines the manifest item."""
+        return (self.path, self.start, self.end)
+
+
+class ShardLevelManifest(ItemizedManifest):
+    """A detailed manifest, recording integrity of every model file."""
+
+    def __init__(self, items: Iterable[ShardedFileManifestItem]):
+        """Builds an itemized manifest from a collection of files.
+
+        Rather than recording the items in a list, we use a dictionary, to allow
+        efficient updates and retrieval of digests.
+        """
+        self._digest_info = {item.input_tuple: item.digest for item in items}
+
+    def __eq__(self, other: Self):
+        return self._digest_info == other._digest_info

--- a/model_signing/manifest/manifest_test.py
+++ b/model_signing/manifest/manifest_test.py
@@ -1,0 +1,72 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+
+from model_signing.hashing import hashing
+from model_signing.manifest import manifest
+
+
+class TestFileLevelManifest:
+
+    def test_insert_order_does_not_matter(self):
+        path1 = pathlib.PurePath("file1")
+        digest1 = hashing.Digest("test", "abcd")
+        item1 = manifest.FileManifestItem(path=path1, digest=digest1)
+
+        path2 = pathlib.PurePath("file2")
+        digest2 = hashing.Digest("test", "efgh")
+        item2 = manifest.FileManifestItem(path=path2, digest=digest2)
+
+        manifest1 = manifest.FileLevelManifest([item1, item2])
+        manifest2 = manifest.FileLevelManifest([item2, item1])
+
+        assert manifest1 == manifest2
+
+
+class TestShardLevelManifest:
+
+    def test_insert_order_does_not_matter(self):
+        path1 = pathlib.PurePath("file1")
+        digest1 = hashing.Digest("test", "abcd")
+        item1 = manifest.ShardedFileManifestItem(
+            path=path1, digest=digest1, start=0, end=4
+        )
+
+        path2 = pathlib.PurePath("file2")
+        digest2 = hashing.Digest("test", "efgh")
+        item2 = manifest.ShardedFileManifestItem(
+            path=path2, digest=digest2, start=0, end=4
+        )
+
+        manifest1 = manifest.ShardLevelManifest([item1, item2])
+        manifest2 = manifest.ShardLevelManifest([item2, item1])
+
+        assert manifest1 == manifest2
+
+    def test_same_path_different_shards_gives_different_manifest(self):
+        path = pathlib.PurePath("file")
+        digest = hashing.Digest("test", "abcd")
+
+        item = manifest.ShardedFileManifestItem(
+            path=path, digest=digest, start=0, end=2
+        )
+        manifest1 = manifest.ShardLevelManifest([item])
+
+        item = manifest.ShardedFileManifestItem(
+            path=path, digest=digest, start=2, end=4
+        )
+        manifest2 = manifest.ShardLevelManifest([item])
+
+        assert manifest1 != manifest2

--- a/model_signing/manifest/manifest_test.py
+++ b/model_signing/manifest/manifest_test.py
@@ -22,11 +22,11 @@ class TestFileLevelManifest:
 
     def test_insert_order_does_not_matter(self):
         path1 = pathlib.PurePath("file1")
-        digest1 = hashing.Digest("test", "abcd")
+        digest1 = hashing.Digest("test", b"abcd")
         item1 = manifest.FileManifestItem(path=path1, digest=digest1)
 
         path2 = pathlib.PurePath("file2")
-        digest2 = hashing.Digest("test", "efgh")
+        digest2 = hashing.Digest("test", b"efgh")
         item2 = manifest.FileManifestItem(path=path2, digest=digest2)
 
         manifest1 = manifest.FileLevelManifest([item1, item2])
@@ -39,13 +39,13 @@ class TestShardLevelManifest:
 
     def test_insert_order_does_not_matter(self):
         path1 = pathlib.PurePath("file1")
-        digest1 = hashing.Digest("test", "abcd")
+        digest1 = hashing.Digest("test", b"abcd")
         item1 = manifest.ShardedFileManifestItem(
             path=path1, digest=digest1, start=0, end=4
         )
 
         path2 = pathlib.PurePath("file2")
-        digest2 = hashing.Digest("test", "efgh")
+        digest2 = hashing.Digest("test", b"efgh")
         item2 = manifest.ShardedFileManifestItem(
             path=path2, digest=digest2, start=0, end=4
         )
@@ -57,7 +57,7 @@ class TestShardLevelManifest:
 
     def test_same_path_different_shards_gives_different_manifest(self):
         path = pathlib.PurePath("file")
-        digest = hashing.Digest("test", "abcd")
+        digest = hashing.Digest("test", b"abcd")
 
         item = manifest.ShardedFileManifestItem(
             path=path, digest=digest, start=0, end=2

--- a/model_signing/serialization/itemized.py
+++ b/model_signing/serialization/itemized.py
@@ -37,18 +37,18 @@ class FilesSerializer(serialization.Serializer):
 
     def __init__(
         self,
-        hasher_factory: Callable[[pathlib.Path], file.FileHasher],
+        file_hasher_factory: Callable[[pathlib.Path], file.FileHasher],
         max_workers: int | None = None,
     ):
         """Initializes an instance to serialize a model with this serializer.
 
         Args:
-            hasher_factory: A callable to build the hash engine used to hash
-              individual files.
+            file_hasher_factory: A callable to build the hash engine used to
+              hash individual files.
             max_workers: Maximum number of workers to use in parallel. Default
               is to defer to the `concurent.futures` library.
         """
-        self._hasher_factory = hasher_factory
+        self._hasher_factory = file_hasher_factory
         self._max_workers = max_workers
 
     @override
@@ -124,7 +124,7 @@ class ShardedFilesSerializer(serialization.Serializer):
 
     def __init__(
         self,
-        hasher_factory: Callable[
+        sharded_hasher_factory: Callable[
             [pathlib.Path, int, int], file.ShardedFileHasher
         ],
         max_workers: int | None = None,
@@ -132,15 +132,15 @@ class ShardedFilesSerializer(serialization.Serializer):
         """Initializes an instance to serialize a model with this serializer.
 
         Args:
-            hasher_factory: A callable to build the hash engine used to hash
-              every shard of the files in the model. Because each shard is
+            sharded_hasher_factory: A callable to build the hash engine used to
+              hash every shard of the files in the model. Because each shard is
               processed in parallel, every thread needs to call the factory to
               start hashing. The arguments are the file, and the endpoints of
               the shard.
             max_workers: Maximum number of workers to use in parallel. Default
               is to defer to the `concurent.futures` library.
         """
-        self._hasher_factory = hasher_factory
+        self._hasher_factory = sharded_hasher_factory
         self._max_workers = max_workers
 
         # Precompute some private values only once by using a mock file hasher.

--- a/model_signing/serialization/itemized.py
+++ b/model_signing/serialization/itemized.py
@@ -96,7 +96,8 @@ class FilesSerializer(serialization.Serializer):
         Returns:
             The itemized manifest.
         """
-        relative_path = path.relative_to(model_path)
+        # Note: we need to force a PosixPath to canonicalize the manifest
+        relative_path = pathlib.PurePosixPath(path.relative_to(model_path))
         digest = self._hasher_factory(path).compute()
         return manifest.FileManifestItem(path=relative_path, digest=digest)
 
@@ -209,7 +210,8 @@ class ShardedFilesSerializer(serialization.Serializer):
         Returns:
             The itemized manifest.
         """
-        relative_path = path.relative_to(model_path)
+        # Note: we need to force a PosixPath to canonicalize the manifest
+        relative_path = pathlib.PurePosixPath(path.relative_to(model_path))
         digest = self._hasher_factory(path, start, end).compute()
         return manifest.ShardedFileManifestItem(
             path=relative_path, digest=digest, start=start, end=end

--- a/model_signing/serialization/itemized.py
+++ b/model_signing/serialization/itemized.py
@@ -14,9 +14,10 @@
 
 """Model serializers that build an itemized manifest."""
 
+from collections.abc import Iterable
 import concurrent.futures
 import pathlib
-from typing import Callable, Iterable
+from typing import Callable
 from typing_extensions import override
 
 from model_signing.hashing import file
@@ -46,7 +47,7 @@ class FilesSerializer(serialization.Serializer):
             file_hasher_factory: A callable to build the hash engine used to
               hash individual files.
             max_workers: Maximum number of workers to use in parallel. Default
-              is to defer to the `concurent.futures` library.
+              is to defer to the `concurrent.futures` library.
         """
         self._hasher_factory = file_hasher_factory
         self._max_workers = max_workers
@@ -137,7 +138,7 @@ class ShardedFilesSerializer(serialization.Serializer):
               start hashing. The arguments are the file, and the endpoints of
               the shard.
             max_workers: Maximum number of workers to use in parallel. Default
-              is to defer to the `concurent.futures` library.
+              is to defer to the `concurrent.futures` library.
         """
         self._hasher_factory = sharded_hasher_factory
         self._max_workers = max_workers

--- a/model_signing/serialization/itemized.py
+++ b/model_signing/serialization/itemized.py
@@ -145,7 +145,7 @@ class ShardedFilesSerializer(serialization.Serializer):
 
         # Precompute some private values only once by using a mock file hasher.
         # None of the arguments used to build the hasher are used.
-        hasher = hasher_factory(pathlib.Path(), 0, 1)
+        hasher = sharded_hasher_factory(pathlib.Path(), 0, 1)
         self._shard_size = hasher.shard_size
 
     @override

--- a/model_signing/serialization/itemized.py
+++ b/model_signing/serialization/itemized.py
@@ -1,0 +1,226 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model serializers that build an itemized manifest."""
+
+import concurrent.futures
+import pathlib
+from typing import Callable, Iterable
+from typing_extensions import override
+
+from model_signing.hashing import file
+from model_signing.manifest import manifest
+from model_signing.serialization import dfs
+from model_signing.serialization import serialization
+
+
+class FilesSerializer(serialization.Serializer):
+    """Model serializers that produces an itemized manifest, at file level.
+
+    Traverses the model directory and creates digests for every file found,
+    possibly in parallel.
+
+    Since the manifest lists each item individually, this will also enable
+    support for incremental updates (to be added later).
+    """
+
+    def __init__(
+        self,
+        hasher_factory: Callable[[pathlib.Path], file.FileHasher],
+        max_workers: int | None = None,
+    ):
+        """Initializes an instance to serialize a model with this serializer.
+
+        Args:
+            hasher_factory: A callable to build the hash engine used to hash
+              individual files.
+            max_workers: Maximum number of workers to use in parallel. Default
+              is to defer to the `concurent.futures` library.
+        """
+        self._hasher_factory = hasher_factory
+        self._max_workers = max_workers
+
+    @override
+    def serialize(self, model_path: pathlib.Path) -> manifest.FileLevelManifest:
+        # TODO: github.com/sigstore/model-transparency/issues/196 - Add checks
+        # to exclude symlinks if desired.
+        dfs.check_file_or_directory(model_path)
+
+        paths = []
+        if model_path.is_file():
+            paths.append(model_path)
+        else:
+            # TODO: github.com/sigstore/model-transparency/issues/200 - When
+            # Python3.12 is the minimum supported version, this can be replaced
+            # with `pathlib.Path.walk` for a clearer interface, and some speed
+            # improvement.
+            for path in model_path.glob("**/*"):
+                dfs.check_file_or_directory(path)
+                if path.is_file():
+                    paths.append(path)
+
+        manifest_items = []
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self._max_workers
+        ) as tpe:
+            futures = [
+                tpe.submit(self._compute_hash, model_path, path)
+                for path in paths
+            ]
+            for future in concurrent.futures.as_completed(futures):
+                manifest_items.append(future.result())
+
+        return self._build_manifest(manifest_items)
+
+    def _compute_hash(
+        self, model_path: pathlib.Path, path: pathlib.Path
+    ) -> manifest.FileManifestItem:
+        """Produces the manifest item of the file given by `path`.
+
+        Args:
+            model_path: The path to the model.
+            path: Path to the file in the model, that is currently transformed
+              to a manifest item.
+
+        Returns:
+            The itemized manifest.
+        """
+        relative_path = path.relative_to(model_path)
+        digest = self._hasher_factory(path).compute()
+        return manifest.FileManifestItem(path=relative_path, digest=digest)
+
+    def _build_manifest(
+        self, items: Iterable[manifest.FileManifestItem]
+    ) -> manifest.FileLevelManifest:
+        """Builds an itemized manifest from a given list of items.
+
+        Every subclass needs to implement this method to determine the format of
+        the manifest.
+        """
+        return manifest.FileLevelManifest(items)
+
+
+class ShardedFilesSerializer(serialization.Serializer):
+    """Model serializers that produces an itemized manifest, at shard level.
+
+    Traverses the model directory and creates digests for every file found,
+    sharding the file in equal shards and computing the digests in parallel.
+
+    Since the manifest lists each item individually, this will also enable
+    support for incremental updates (to be added later).
+    """
+
+    def __init__(
+        self,
+        hasher_factory: Callable[
+            [pathlib.Path, int, int], file.ShardedFileHasher
+        ],
+        max_workers: int | None = None,
+    ):
+        """Initializes an instance to serialize a model with this serializer.
+
+        Args:
+            hasher_factory: A callable to build the hash engine used to hash
+              every shard of the files in the model. Because each shard is
+              processed in parallel, every thread needs to call the factory to
+              start hashing. The arguments are the file, and the endpoints of
+              the shard.
+            max_workers: Maximum number of workers to use in parallel. Default
+              is to defer to the `concurent.futures` library.
+        """
+        self._hasher_factory = hasher_factory
+        self._max_workers = max_workers
+
+        # Precompute some private values only once by using a mock file hasher.
+        # None of the arguments used to build the hasher are used.
+        hasher = hasher_factory(pathlib.Path(), 0, 1)
+        self._shard_size = hasher.shard_size
+
+    @override
+    def serialize(
+        self, model_path: pathlib.Path
+    ) -> manifest.ShardLevelManifest:
+        # TODO: github.com/sigstore/model-transparency/issues/196 - Add checks
+        # to exclude symlinks if desired.
+        dfs.check_file_or_directory(model_path)
+
+        shards = []
+        if model_path.is_file():
+            shards.extend(self._get_shards(model_path))
+        else:
+            # TODO: github.com/sigstore/model-transparency/issues/200 - When
+            # Python3.12 is the minimum supported version, this can be replaced
+            # with `pathlib.Path.walk` for a clearer interface, and some speed
+            # improvement.
+            for path in model_path.glob("**/*"):
+                dfs.check_file_or_directory(path)
+                if path.is_file():
+                    shards.extend(self._get_shards(path))
+
+        manifest_items = []
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self._max_workers
+        ) as tpe:
+            futures = [
+                tpe.submit(self._compute_hash, model_path, path, start, end)
+                for path, start, end in shards
+            ]
+            for future in concurrent.futures.as_completed(futures):
+                manifest_items.append(future.result())
+
+        return self._build_manifest(manifest_items)
+
+    def _get_shards(
+        self, path: pathlib.Path
+    ) -> list[tuple[pathlib.Path, int, int]]:
+        """Determines the shards of a given file path."""
+        shards = []
+        path_size = path.stat().st_size
+        if path_size > 0:
+            start = 0
+            for end in dfs.endpoints(self._shard_size, path_size):
+                shards.append((path, start, end))
+                start = end
+        return shards
+
+    def _compute_hash(
+        self, model_path: pathlib.Path, path: pathlib.Path, start: int, end: int
+    ) -> manifest.ShardedFileManifestItem:
+        """Produces the manifest item of the file given by `path`.
+
+        Args:
+            model_path: The path to the model.
+            path: Path to the file in the model, that is currently transformed
+              to a manifest item.
+            start: Offset for the start of the path shard.
+            end: Offset for the end of the path shard.
+
+        Returns:
+            The itemized manifest.
+        """
+        relative_path = path.relative_to(model_path)
+        digest = self._hasher_factory(path, start, end).compute()
+        return manifest.ShardedFileManifestItem(
+            path=relative_path, digest=digest, start=start, end=end
+        )
+
+    def _build_manifest(
+        self, items: Iterable[manifest.ShardedFileManifestItem]
+    ) -> manifest.ShardLevelManifest:
+        """Builds an itemized manifest from a given list of items.
+
+        Every subclass needs to implement this method to determine the format of
+        the manifest.
+        """
+        return manifest.ShardLevelManifest(items)

--- a/model_signing/serialization/itemized.py
+++ b/model_signing/serialization/itemized.py
@@ -96,8 +96,7 @@ class FilesSerializer(serialization.Serializer):
         Returns:
             The itemized manifest.
         """
-        # Note: we need to force a PosixPath to canonicalize the manifest
-        relative_path = pathlib.PurePosixPath(path.relative_to(model_path))
+        relative_path = path.relative_to(model_path)
         digest = self._hasher_factory(path).compute()
         return manifest.FileManifestItem(path=relative_path, digest=digest)
 
@@ -210,8 +209,7 @@ class ShardedFilesSerializer(serialization.Serializer):
         Returns:
             The itemized manifest.
         """
-        # Note: we need to force a PosixPath to canonicalize the manifest
-        relative_path = pathlib.PurePosixPath(path.relative_to(model_path))
+        relative_path = path.relative_to(model_path)
         digest = self._hasher_factory(path, start, end).compute()
         return manifest.ShardedFileManifestItem(
             path=relative_path, digest=digest, start=start, end=end

--- a/model_signing/serialization/itemized.py
+++ b/model_signing/serialization/itemized.py
@@ -204,8 +204,8 @@ class ShardedFilesSerializer(serialization.Serializer):
             model_path: The path to the model.
             path: Path to the file in the model, that is currently transformed
               to a manifest item.
-            start: Offset for the start of the path shard.
-            end: Offset for the end of the path shard.
+            start: The start offset of the shard (included).
+            end: The end offset of the shard (not included).
 
         Returns:
             The itemized manifest.

--- a/model_signing/serialization/itemized_test.py
+++ b/model_signing/serialization/itemized_test.py
@@ -14,7 +14,6 @@
 
 import os
 import pathlib
-from typing import Dict, List, Tuple
 import pytest
 
 from model_signing.hashing import file
@@ -30,7 +29,7 @@ pytest_plugins = ("model_signing.serialization.fixtures",)
 
 def _extract_digests_from_manifest(
     manifest: manifest.FileLevelManifest,
-) -> List[str]:
+) -> list[str]:
     """Extracts the hex digest for every subject in a manifest.
 
     Used in multiple tests to check that we obtained the expected digests.
@@ -40,7 +39,7 @@ def _extract_digests_from_manifest(
 
 def _extract_items_from_manifest(
     manifest: manifest.FileLevelManifest,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Builds a dictionary representation of the items in a manifest.
 
     Every item is mapped to its digest.
@@ -55,7 +54,7 @@ def _extract_items_from_manifest(
 
 def _extract_shard_items_from_manifest(
     manifest: manifest.ShardLevelManifest,
-) -> Dict[Tuple[str, int, int], str]:
+) -> dict[tuple[str, int, int], str]:
     """Builds a dictionary representation of the items in a manifest.
 
     Every item is mapped to its digest.

--- a/model_signing/serialization/itemized_test.py
+++ b/model_signing/serialization/itemized_test.py
@@ -1,0 +1,825 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pathlib
+import pytest
+
+from model_signing.hashing import file
+from model_signing.hashing import hashing
+from model_signing.hashing import memory
+from model_signing.manifest import manifest
+from model_signing.serialization import fixtures_constants
+from model_signing.serialization import itemized
+
+
+# Load fixtures from serialization/fixtures.py
+pytest_plugins = ("model_signing.serialization.fixtures",)
+
+
+class TestFilesSerializer:
+
+    def _hasher_factory(self, path: pathlib.Path) -> file.FileHasher:
+        return file.FileHasher(path, memory.SHA256())
+
+    def test_known_file(self, sample_model_file):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        expected = [
+            "3aab065c7181a173b5dd9e9d32a9f79923440b413be1e1ffcdba26a7365f719b"
+        ]
+
+        manifest = serializer.serialize(sample_model_file)
+        digests = [d.digest_hex for d in manifest._digest_info.values()]
+
+        assert digests == expected
+
+    def test_file_manifest_unchanged_when_model_moved(self, sample_model_file):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_file)
+
+        new_name = sample_model_file.with_name("new-file")
+        new_file = sample_model_file.rename(new_name)
+        new_manifest = serializer.serialize(new_file)
+
+        assert manifest == new_manifest
+
+    def test_file_manifest_changes_if_content_changes(self, sample_model_file):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_file)
+        digests = set(
+            digest.digest_hex for digest in manifest._digest_info.values()
+        )
+
+        sample_model_file.write_bytes(fixtures_constants.ANOTHER_MODEL_TEXT)
+        new_manifest = serializer.serialize(sample_model_file)
+        new_digests = set(
+            digest.digest_hex for digest in new_manifest._digest_info.values()
+        )
+
+        assert manifest != new_manifest
+        assert digests != new_digests
+        assert len(digests) == len(new_digests)
+
+    def test_directory_model_with_one_single_file(self, sample_model_file):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        manifest_file = serializer.serialize(sample_model_file)
+        digests_file = set(
+            digest.digest_hex for digest in manifest_file._digest_info.values()
+        )
+
+        manifest = serializer.serialize(sample_model_file.parent)
+        digests = set(
+            digest.digest_hex for digest in manifest._digest_info.values()
+        )
+
+        assert manifest != manifest_file  # different paths
+        assert digests == digests_file
+
+    def test_known_folder(self, sample_model_folder):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        # Long hashes, want to update easily, so pylint: disable=line-too-long
+        expected_items = {
+            "f0": "997b37cc51f1ca1c7a270466607e26847429cd7264c30148c1b9352e224083fc",
+            "f1": "c88a04d48353133fb065ba2c8ab369abab21395b9526aa20373ad828915fa7ae",
+            "f2": "700e3ba5065d8dd47e41fd928ea086670d628f891ba363be0ca3c31d20d7d719",
+            "f3": "912bcf5ebdf44dc7b4085b07940e0a81d157fba24b276e73fd911121d4544c4a",
+            "d0/f00": "fdd8925354242a7fd1515e79534317b800015607a609cd306e0b4dcfe6c92249",
+            "d0/f01": "e16940b5e44ce981150bda37c4ba95881a749a521b4a297c5cdf97bdcfe965e6",
+            "d0/f02": "407822246ea8f9e26380842c3f4cd10d7b23e78f1fe7c74c293608682886a426",
+            "d1/f10": "6a3b08b5df77c4d418ceee1ac136a9ad49fc7c41358b5e82c1176daccb21ff3f",
+            "d1/f11": "a484b3d8ea5e99b75f9f123f9a42c882388693edc7d85d82ccba54834712cadf",
+            "d1/f12": "8f577930f5f40c2c2133cb299d36f9527fde98c1608569017cae6b5bcd01abb3",
+        }
+        # Re-enable lint, so pylint: enable=line-too-long
+
+        manifest = serializer.serialize(sample_model_folder)
+        items = {
+            str(path): digest.digest_hex
+            for path, digest in manifest._digest_info.items()
+        }
+
+        assert items == expected_items
+
+    def test_folder_model_hash_is_same_if_model_is_moved(
+        self, sample_model_folder
+    ):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_folder)
+
+        new_name = sample_model_folder.with_name("new-root")
+        new_model = sample_model_folder.rename(new_name)
+        new_manifest = serializer.serialize(new_model)
+
+        assert manifest == new_manifest
+
+    def test_folder_model_empty_folder_not_included(self, sample_model_folder):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_folder)
+
+        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
+        altered_dir = dirs[0]
+        new_empty_dir = altered_dir / "empty"
+        new_empty_dir.mkdir()
+        new_manifest = serializer.serialize(sample_model_folder)
+
+        assert manifest == new_manifest
+
+    def test_folder_model_empty_file_gets_included(self, sample_model_folder):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_folder)
+
+        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
+        altered_dir = dirs[0]
+        new_empty_file = altered_dir / "empty"
+        new_empty_file.write_text("")
+        new_manifest = serializer.serialize(sample_model_folder)
+
+        assert manifest != new_manifest
+        assert len(new_manifest._digest_info) == len(manifest._digest_info) + 1
+        for path, digest in manifest._digest_info.items():
+            assert new_manifest._digest_info[path] == digest
+
+    def test_folder_model_rename_file_only_changes_path_part(
+        self, sample_model_folder
+    ):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_folder)
+
+        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
+        altered_dir = dirs[0]
+        files = [f for f in altered_dir.iterdir() if f.is_file()]
+        file_to_rename = files[0]
+        old_name = file_to_rename.relative_to(sample_model_folder)
+        new_name = file_to_rename.with_name("new-file")
+        file_to_rename.rename(new_name)
+        new_manifest = serializer.serialize(sample_model_folder)
+
+        assert manifest != new_manifest
+        assert len(new_manifest._digest_info) == len(manifest._digest_info)
+        for path, digest in new_manifest._digest_info.items():
+            if path.name == "new-file":
+                assert manifest._digest_info[old_name] == digest
+            else:
+                assert manifest._digest_info[path] == digest
+
+    def test_folder_model_rename_dir_only_changes_path_part(
+        self, sample_model_folder
+    ):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_folder)
+
+        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
+        dir_to_rename = dirs[0]
+        old_name = dir_to_rename.name
+        new_name = dir_to_rename.with_name("new-dir")
+        dir_to_rename.rename(new_name)
+        new_manifest = serializer.serialize(sample_model_folder)
+
+        assert manifest != new_manifest
+        assert len(new_manifest._digest_info) == len(manifest._digest_info)
+        for path, digest in new_manifest._digest_info.items():
+            if "new-dir" in path.parts:
+                parts = [
+                    old_name if part == "new-dir" else part
+                    for part in path.parts
+                ]
+                old = pathlib.Path(*parts)
+                assert manifest._digest_info[old] == digest
+            else:
+                assert manifest._digest_info[path] == digest
+
+    def test_folder_model_replace_file_empty_folder(self, sample_model_folder):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_folder)
+
+        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
+        altered_dir = dirs[0]
+        files = [f for f in altered_dir.iterdir() if f.is_file()]
+        file_to_replace = files[0]
+        file_to_replace.unlink()
+        file_to_replace.mkdir()
+        new_manifest = serializer.serialize(sample_model_folder)
+
+        assert manifest != new_manifest
+        assert len(new_manifest._digest_info) == len(manifest._digest_info) - 1
+        for path, digest in new_manifest._digest_info.items():
+            assert manifest._digest_info[path] == digest
+
+    def test_folder_model_change_file(self, sample_model_folder):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_folder)
+
+        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
+        altered_dir = dirs[0]
+        files = [f for f in altered_dir.iterdir() if f.is_file()]
+        file_to_change = files[0]
+        file_to_change.write_bytes(fixtures_constants.KNOWN_MODEL_TEXT)
+        new_manifest = serializer.serialize(sample_model_folder)
+
+        assert manifest != new_manifest
+        assert len(new_manifest._digest_info) == len(manifest._digest_info)
+        for path, digest in new_manifest._digest_info.items():
+            if path == file_to_change.relative_to(sample_model_folder):
+                assert manifest._digest_info[path] != digest
+            else:
+                assert manifest._digest_info[path] == digest
+
+    def test_deep_folder(self, deep_model_folder):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        # Long hashes, want to update easily, so pylint: disable=line-too-long
+        expected_items = {
+            "d0/d1/d2/d3/d4/f0": "6efa14bb03544fcb76045c55f25b9315b6eb5be2d8a85f703193a76b7874c6ff",
+            "d0/d1/d2/d3/d4/f1": "a9bc149b70b9d325cd68d275d582cfdb98c0347d3ce54590aa6533368daed3d2",
+            "d0/d1/d2/d3/d4/f2": "5f597e6a92d1324d9adbed43d527926d11d0131487baf315e65ae1ef3b1ca3c0",
+            "d0/d1/d2/d3/d4/f3": "eaf677c35fec6b87889d9e4563d8bb65dcb9869ca0225697c9cc44cf49dca008",
+        }
+        # Re-enable lint, so pylint: enable=line-too-long
+
+        manifest = serializer.serialize(deep_model_folder)
+        items = {
+            str(path): digest.digest_hex
+            for path, digest in manifest._digest_info.items()
+        }
+
+        assert items == expected_items
+
+    def test_empty_file(self, empty_model_file):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        expected = [
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        ]
+
+        manifest = serializer.serialize(empty_model_file)
+        digests = [d.digest_hex for d in manifest._digest_info.values()]
+
+        assert digests == expected
+
+    def test_empty_folder(self, empty_model_folder):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(empty_model_folder)
+        assert not manifest._digest_info
+
+    def test_special_file(self, sample_model_folder):
+        serializer = itemized.FilesSerializer(self._hasher_factory)
+
+        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
+        altered_dir = dirs[0]
+        pipe = altered_dir / "pipe"
+
+        try:
+            os.mkfifo(pipe)
+        except AttributeError:
+            # On Windows, `os.mkfifo` does not exist (it should not).
+            return  # trivially pass the test
+
+        with pytest.raises(
+            ValueError, match="Cannot use .* as file or directory"
+        ):
+            serializer.serialize(sample_model_folder)
+
+        with pytest.raises(
+            ValueError, match="Cannot use .* as file or directory"
+        ):
+            serializer.serialize(pipe)
+
+    def test_max_workers_does_not_change_digest(self, sample_model_folder):
+        serializer1 = itemized.FilesSerializer(self._hasher_factory)
+        serializer2 = itemized.FilesSerializer(
+            self._hasher_factory, max_workers=1
+        )
+        serializer3 = itemized.FilesSerializer(
+            self._hasher_factory, max_workers=3
+        )
+
+        manifest1 = serializer1.serialize(sample_model_folder)
+        manifest2 = serializer2.serialize(sample_model_folder)
+        manifest3 = serializer3.serialize(sample_model_folder)
+
+        assert manifest1 == manifest2
+        assert manifest1 == manifest3
+
+
+class TestShardedFilesSerializer:
+
+    def _hasher_factory(
+        self, path: pathlib.Path, start: int, end: int
+    ) -> file.ShardedFileHasher:
+        return file.ShardedFileHasher(
+            path, memory.SHA256(), start=start, end=end
+        )
+
+    def _hasher_factory_small_shards(
+        self, path: pathlib.Path, start: int, end: int
+    ) -> file.ShardedFileHasher:
+        return file.ShardedFileHasher(
+            path, memory.SHA256(), start=start, end=end, shard_size=8
+        )
+
+    def test_known_file(self, sample_model_file):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        expected = [
+            "3aab065c7181a173b5dd9e9d32a9f79923440b413be1e1ffcdba26a7365f719b"
+        ]
+
+        manifest = serializer.serialize(sample_model_file)
+        digests = [d.digest_hex for d in manifest._digest_info.values()]
+
+        assert digests == expected
+
+    def test_file_manifest_unchanged_when_model_moved(self, sample_model_file):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_file)
+
+        new_name = sample_model_file.with_name("new-file")
+        new_file = sample_model_file.rename(new_name)
+        new_manifest = serializer.serialize(new_file)
+
+        assert manifest == new_manifest
+
+    def test_file_manifest_changes_if_content_changes(self, sample_model_file):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_file)
+        digests = set(
+            digest.digest_hex for digest in manifest._digest_info.values()
+        )
+
+        sample_model_file.write_bytes(fixtures_constants.ANOTHER_MODEL_TEXT)
+        new_manifest = serializer.serialize(sample_model_file)
+        new_digests = set(
+            digest.digest_hex for digest in new_manifest._digest_info.values()
+        )
+
+        assert manifest != new_manifest
+        assert len(digests) == len(new_digests)
+        assert digests != new_digests
+
+    def test_directory_model_with_one_single_file(self, sample_model_file):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        manifest_file = serializer.serialize(sample_model_file)
+        digests_file = set(
+            digest.digest_hex for digest in manifest_file._digest_info.values()
+        )
+
+        manifest = serializer.serialize(sample_model_file.parent)
+        digests = set(
+            digest.digest_hex for digest in manifest._digest_info.values()
+        )
+
+        assert manifest != manifest_file  # different paths
+        assert digests == digests_file
+
+    def test_known_folder(self, sample_model_folder):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        # Long hashes, want to update easily, so pylint: disable=line-too-long
+        expected_items = {
+            (
+                "f0",
+                0,
+                24,
+            ): "997b37cc51f1ca1c7a270466607e26847429cd7264c30148c1b9352e224083fc",
+            (
+                "f1",
+                0,
+                24,
+            ): "c88a04d48353133fb065ba2c8ab369abab21395b9526aa20373ad828915fa7ae",
+            (
+                "f2",
+                0,
+                24,
+            ): "700e3ba5065d8dd47e41fd928ea086670d628f891ba363be0ca3c31d20d7d719",
+            (
+                "f3",
+                0,
+                24,
+            ): "912bcf5ebdf44dc7b4085b07940e0a81d157fba24b276e73fd911121d4544c4a",
+            (
+                "d0/f00",
+                0,
+                23,
+            ): "fdd8925354242a7fd1515e79534317b800015607a609cd306e0b4dcfe6c92249",
+            (
+                "d0/f01",
+                0,
+                23,
+            ): "e16940b5e44ce981150bda37c4ba95881a749a521b4a297c5cdf97bdcfe965e6",
+            (
+                "d0/f02",
+                0,
+                23,
+            ): "407822246ea8f9e26380842c3f4cd10d7b23e78f1fe7c74c293608682886a426",
+            (
+                "d1/f10",
+                0,
+                23,
+            ): "6a3b08b5df77c4d418ceee1ac136a9ad49fc7c41358b5e82c1176daccb21ff3f",
+            (
+                "d1/f11",
+                0,
+                23,
+            ): "a484b3d8ea5e99b75f9f123f9a42c882388693edc7d85d82ccba54834712cadf",
+            (
+                "d1/f12",
+                0,
+                23,
+            ): "8f577930f5f40c2c2133cb299d36f9527fde98c1608569017cae6b5bcd01abb3",
+        }
+        # Re-enable lint, so pylint: enable=line-too-long
+
+        manifest = serializer.serialize(sample_model_folder)
+        items = {
+            # convert to file path (relative to model) string and endpoints
+            (str(shard[0]), shard[1], shard[2]): digest.digest_hex
+            for shard, digest in manifest._digest_info.items()
+        }
+
+        assert items == expected_items
+
+    def test_folder_model_hash_is_same_if_model_is_moved(
+        self, sample_model_folder
+    ):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_folder)
+
+        new_name = sample_model_folder.with_name("new-root")
+        new_model = sample_model_folder.rename(new_name)
+        new_manifest = serializer.serialize(new_model)
+
+        assert manifest == new_manifest
+
+    def test_folder_model_empty_folder_not_included(self, sample_model_folder):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_folder)
+
+        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
+        altered_dir = dirs[0]
+        new_empty_dir = altered_dir / "empty"
+        new_empty_dir.mkdir()
+        new_manifest = serializer.serialize(sample_model_folder)
+
+        assert manifest == new_manifest
+
+    def test_folder_model_empty_file_not_included(self, sample_model_folder):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_folder)
+
+        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
+        altered_dir = dirs[0]
+        new_empty_file = altered_dir / "empty"
+        new_empty_file.write_text("")
+        new_manifest = serializer.serialize(sample_model_folder)
+
+        assert manifest == new_manifest
+
+    def test_folder_model_rename_file_only_changes_path_part(
+        self, sample_model_folder
+    ):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_folder)
+
+        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
+        altered_dir = dirs[0]
+        files = [f for f in altered_dir.iterdir() if f.is_file()]
+        file_to_rename = files[0]
+        old_name = file_to_rename.relative_to(sample_model_folder)
+        new_name = file_to_rename.with_name("new-file")
+        file_to_rename.rename(new_name)
+        new_manifest = serializer.serialize(sample_model_folder)
+
+        assert manifest != new_manifest
+        assert len(new_manifest._digest_info) == len(manifest._digest_info)
+        for shard, digest in new_manifest._digest_info.items():
+            path, start, end = shard
+            if path.name == "new-file":
+                old_shard = (old_name, start, end)
+                assert manifest._digest_info[old_shard] == digest
+            else:
+                assert manifest._digest_info[shard] == digest
+
+    def test_folder_model_rename_dir_only_changes_path_part(
+        self, sample_model_folder
+    ):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_folder)
+
+        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
+        dir_to_rename = dirs[0]
+        old_name = dir_to_rename.name
+        new_name = dir_to_rename.with_name("new-dir")
+        dir_to_rename.rename(new_name)
+        new_manifest = serializer.serialize(sample_model_folder)
+
+        assert manifest != new_manifest
+        assert len(new_manifest._digest_info) == len(manifest._digest_info)
+        for shard, digest in new_manifest._digest_info.items():
+            path, start, end = shard
+            if "new-dir" in path.parts:
+                parts = [
+                    old_name if part == "new-dir" else part
+                    for part in path.parts
+                ]
+                old = (pathlib.Path(*parts), start, end)
+                assert manifest._digest_info[old] == digest
+            else:
+                assert manifest._digest_info[shard] == digest
+
+    def test_folder_model_replace_file_empty_folder(self, sample_model_folder):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_folder)
+
+        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
+        altered_dir = dirs[0]
+        files = [f for f in altered_dir.iterdir() if f.is_file()]
+        file_to_replace = files[0]
+        file_to_replace.unlink()
+        file_to_replace.mkdir()
+        new_manifest = serializer.serialize(sample_model_folder)
+
+        assert manifest != new_manifest
+        assert len(new_manifest._digest_info) == len(manifest._digest_info) - 1
+        for path, digest in new_manifest._digest_info.items():
+            assert manifest._digest_info[path] == digest
+
+    def test_folder_model_change_file(self, sample_model_folder):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(sample_model_folder)
+
+        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
+        altered_dir = dirs[0]
+        files = [f for f in altered_dir.iterdir() if f.is_file()]
+        file_to_change = files[0]
+        file_to_change.write_bytes(fixtures_constants.KNOWN_MODEL_TEXT)
+        new_manifest = serializer.serialize(sample_model_folder)
+
+        assert manifest != new_manifest
+        assert len(new_manifest._digest_info) == len(manifest._digest_info)
+        for shard, digest in new_manifest._digest_info.items():
+            path, _, _ = shard
+            if path == file_to_change.relative_to(sample_model_folder):
+                # Note that the file size changes
+                assert manifest._digest_info[(path, 0, 23)] != digest
+            else:
+                assert manifest._digest_info[shard] == digest
+
+    def test_deep_folder(self, deep_model_folder):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        # Long hashes, want to update easily, so pylint: disable=line-too-long
+        expected_items = {
+            (
+                "d0/d1/d2/d3/d4/f0",
+                0,
+                16,
+            ): "6efa14bb03544fcb76045c55f25b9315b6eb5be2d8a85f703193a76b7874c6ff",
+            (
+                "d0/d1/d2/d3/d4/f1",
+                0,
+                16,
+            ): "a9bc149b70b9d325cd68d275d582cfdb98c0347d3ce54590aa6533368daed3d2",
+            (
+                "d0/d1/d2/d3/d4/f2",
+                0,
+                16,
+            ): "5f597e6a92d1324d9adbed43d527926d11d0131487baf315e65ae1ef3b1ca3c0",
+            (
+                "d0/d1/d2/d3/d4/f3",
+                0,
+                16,
+            ): "eaf677c35fec6b87889d9e4563d8bb65dcb9869ca0225697c9cc44cf49dca008",
+        }
+        # Re-enable lint, so pylint: enable=line-too-long
+
+        manifest = serializer.serialize(deep_model_folder)
+        items = {
+            # convert to file path (relative to model) string and endpoints
+            (str(shard[0]), shard[1], shard[2]): digest.digest_hex
+            for shard, digest in manifest._digest_info.items()
+        }
+
+        assert items == expected_items
+
+    def test_empty_file(self, empty_model_file):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(empty_model_file)
+        assert not manifest._digest_info
+
+    def test_empty_folder(self, empty_model_folder):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+        manifest = serializer.serialize(empty_model_folder)
+        assert not manifest._digest_info
+
+    def test_special_file(self, sample_model_folder):
+        serializer = itemized.ShardedFilesSerializer(self._hasher_factory)
+
+        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
+        altered_dir = dirs[0]
+        pipe = altered_dir / "pipe"
+
+        try:
+            os.mkfifo(pipe)
+        except AttributeError:
+            # On Windows, `os.mkfifo` does not exist (it should not).
+            return  # trivially pass the test
+
+        with pytest.raises(
+            ValueError, match="Cannot use .* as file or directory"
+        ):
+            serializer.serialize(sample_model_folder)
+
+        with pytest.raises(
+            ValueError, match="Cannot use .* as file or directory"
+        ):
+            serializer.serialize(pipe)
+
+    def test_max_workers_does_not_change_digest(self, sample_model_folder):
+        serializer1 = itemized.ShardedFilesSerializer(self._hasher_factory)
+        serializer2 = itemized.ShardedFilesSerializer(
+            self._hasher_factory, max_workers=1
+        )
+        serializer3 = itemized.ShardedFilesSerializer(
+            self._hasher_factory, max_workers=3
+        )
+
+        manifest1 = serializer1.serialize(sample_model_folder)
+        manifest2 = serializer2.serialize(sample_model_folder)
+        manifest3 = serializer3.serialize(sample_model_folder)
+
+        assert manifest1 == manifest2
+        assert manifest1 == manifest3
+
+    def test_known_folder_small_shards(self, sample_model_folder):
+        serializer = itemized.ShardedFilesSerializer(
+            self._hasher_factory_small_shards
+        )
+        # Long hashes, want to update easily, so pylint: disable=line-too-long
+        expected_items = {
+            (
+                "f0",
+                0,
+                8,
+            ): "a37010c994067764d86540bf479d93b4d0c3bb3955de7b61f951caf2fd0301b0",
+            (
+                "f0",
+                8,
+                16,
+            ): "6ceb6f182993c238d6ce291d3f72f0de743d81faff85f4b038f4dffcc0eea50b",
+            (
+                "f0",
+                16,
+                24,
+            ): "df42fcbd1023b80c82e869872ea01e1e1b0bbd60ab4c68c4054e7343ff0ce581",
+            (
+                "f1",
+                0,
+                8,
+            ): "a37010c994067764d86540bf479d93b4d0c3bb3955de7b61f951caf2fd0301b0",
+            (
+                "f1",
+                8,
+                16,
+            ): "be0c7e3632df2704636ebb173240d67568b7736a5e4c86c3e3cdee24e765fe92",
+            (
+                "f1",
+                16,
+                24,
+            ): "df42fcbd1023b80c82e869872ea01e1e1b0bbd60ab4c68c4054e7343ff0ce581",
+            (
+                "f2",
+                0,
+                8,
+            ): "a37010c994067764d86540bf479d93b4d0c3bb3955de7b61f951caf2fd0301b0",
+            (
+                "f2",
+                8,
+                16,
+            ): "336bbabbb79a106f9eecbdeb3f2f6c4949735fdb307c1703dc41a65fbba4faf5",
+            (
+                "f2",
+                16,
+                24,
+            ): "df42fcbd1023b80c82e869872ea01e1e1b0bbd60ab4c68c4054e7343ff0ce581",
+            (
+                "f3",
+                0,
+                8,
+            ): "a37010c994067764d86540bf479d93b4d0c3bb3955de7b61f951caf2fd0301b0",
+            (
+                "f3",
+                8,
+                16,
+            ): "2a40ca276886e04559e3babe13a9baf15fb2e2820befa5db7a0105449a55e77d",
+            (
+                "f3",
+                16,
+                24,
+            ): "df42fcbd1023b80c82e869872ea01e1e1b0bbd60ab4c68c4054e7343ff0ce581",
+            (
+                "d0/f00",
+                0,
+                8,
+            ): "a37010c994067764d86540bf479d93b4d0c3bb3955de7b61f951caf2fd0301b0",
+            (
+                "d0/f00",
+                8,
+                16,
+            ): "03d5bb235fbf6771da18a650a7d01c1d6b85ada9de9cc62d27752a1c2a05548b",
+            (
+                "d0/f00",
+                16,
+                23,
+            ): "003b089e217915b12ca9509b2f8a01be7cfe662ffadeb1cd3cf3f430c7b9773a",
+            (
+                "d0/f01",
+                0,
+                8,
+            ): "a37010c994067764d86540bf479d93b4d0c3bb3955de7b61f951caf2fd0301b0",
+            (
+                "d0/f01",
+                8,
+                16,
+            ): "819b976b5670c9c78a8bed6c2819757b5e2740db5e54e0a4da4b9bb1e5e80234",
+            (
+                "d0/f01",
+                16,
+                23,
+            ): "003b089e217915b12ca9509b2f8a01be7cfe662ffadeb1cd3cf3f430c7b9773a",
+            (
+                "d0/f02",
+                0,
+                8,
+            ): "a37010c994067764d86540bf479d93b4d0c3bb3955de7b61f951caf2fd0301b0",
+            (
+                "d0/f02",
+                8,
+                16,
+            ): "635d7a05841e44a98e10ee9ac8346b8ed51653001a28d5c513a742c1408c7f33",
+            (
+                "d0/f02",
+                16,
+                23,
+            ): "003b089e217915b12ca9509b2f8a01be7cfe662ffadeb1cd3cf3f430c7b9773a",
+            (
+                "d1/f10",
+                0,
+                8,
+            ): "a37010c994067764d86540bf479d93b4d0c3bb3955de7b61f951caf2fd0301b0",
+            (
+                "d1/f10",
+                8,
+                16,
+            ): "be0c2a2c271b113e22b02f495a1fa9b09bcc420b6ce969911827846519533811",
+            (
+                "d1/f10",
+                16,
+                23,
+            ): "e6607ae1f591bd75d53b4a52bcd86ecf08643270814d20950ce4e762a99f773d",
+            (
+                "d1/f11",
+                0,
+                8,
+            ): "a37010c994067764d86540bf479d93b4d0c3bb3955de7b61f951caf2fd0301b0",
+            (
+                "d1/f11",
+                8,
+                16,
+            ): "3a9436f3f057b24fd7f830c6a230a08922b7b5d6f8255ae987bec4773a2d6152",
+            (
+                "d1/f11",
+                16,
+                23,
+            ): "e6607ae1f591bd75d53b4a52bcd86ecf08643270814d20950ce4e762a99f773d",
+            (
+                "d1/f12",
+                0,
+                8,
+            ): "a37010c994067764d86540bf479d93b4d0c3bb3955de7b61f951caf2fd0301b0",
+            (
+                "d1/f12",
+                8,
+                16,
+            ): "93b0ae318b7ff95d0e9afdb975e1c6e7dca2d655d16a6801e0aa128bdfa65726",
+            (
+                "d1/f12",
+                16,
+                23,
+            ): "e6607ae1f591bd75d53b4a52bcd86ecf08643270814d20950ce4e762a99f773d",
+        }
+        # Re-enable lint, so pylint: enable=line-too-long
+
+        manifest = serializer.serialize(sample_model_folder)
+        items = {
+            # convert to file path (relative to model) string and endpoints
+            (str(shard[0]), shard[1], shard[2]): digest.digest_hex
+            for shard, digest in manifest._digest_info.items()
+        }
+
+        assert items == expected_items

--- a/model_signing/serialization/itemized_test.py
+++ b/model_signing/serialization/itemized_test.py
@@ -55,7 +55,7 @@ def _extract_items_from_manifest(
 
 def _extract_shard_items_from_manifest(
     manifest: manifest.ShardLevelManifest,
-) -> Dict[Tuple[str, str, str], str]:
+) -> Dict[Tuple[str, int, int], str]:
     """Builds a dictionary representation of the items in a manifest.
 
     Every item is mapped to its digest.

--- a/model_signing/serialization/itemized_test.py
+++ b/model_signing/serialization/itemized_test.py
@@ -159,6 +159,7 @@ class TestFilesSerializer:
         files = [f for f in altered_dir.iterdir() if f.is_file()]
         file_to_rename = files[0]
         old_name = file_to_rename.relative_to(sample_model_folder)
+        old_name = pathlib.PurePosixPath(old_name)  # canonicalize to Posix
         new_name = file_to_rename.with_name("new-file")
         file_to_rename.rename(new_name)
         new_manifest = serializer.serialize(sample_model_folder)
@@ -192,7 +193,7 @@ class TestFilesSerializer:
                     old_name if part == "new-dir" else part
                     for part in path.parts
                 ]
-                old = pathlib.Path(*parts)
+                old = pathlib.PurePosixPath(*parts)
                 assert manifest._digest_info[old] == digest
             else:
                 assert manifest._digest_info[path] == digest

--- a/model_signing/serialization/itemized_test.py
+++ b/model_signing/serialization/itemized_test.py
@@ -14,16 +14,55 @@
 
 import os
 import pathlib
+from typing import Dict
 import pytest
 
 from model_signing.hashing import file
 from model_signing.hashing import memory
+from model_signing.manifest import manifest
 from model_signing.serialization import fixtures_constants
 from model_signing.serialization import itemized
 
 
 # Load fixtures from serialization/fixtures.py
 pytest_plugins = ("model_signing.serialization.fixtures",)
+
+
+def _extract_digests_from_manifest(manifest: manifest.Manifest) -> [str]:
+    """Extracts the hex digest for every subject in a manifest.
+
+    Used in multiple tests to check that we obtained the expected digests.
+    """
+    return [d.digest_hex for d in manifest._digest_info.values()]
+
+
+def _extract_items_from_manifest(manifest: manifest.Manifest) -> Dict[str, str]:
+    """Builds a dictionary representation of the items in a manifest.
+
+    Every item is mapped to its digest.
+
+    Used in multiple tests to check that we obtained the expected manifest.
+    """
+    return {
+        str(path): digest.digest_hex
+        for path, digest in manifest._digest_info.items()
+    }
+
+
+def _get_first_directory(path: pathlib.Path) -> pathlib.Path:
+    """Returns the first directory that is a children of path.
+
+    It is assumed that there is always such a path.
+    """
+    return [d for d in path.iterdir() if d.is_dir()][0]
+
+
+def _get_first_file(path: pathlib.Path) -> pathlib.Path:
+    """Returns the first file that is a children of path.
+
+    It is assumed that there is always such a path.
+    """
+    return [f for f in path.iterdir() if f.is_file()][0]
 
 
 class TestFilesSerializer:
@@ -38,7 +77,7 @@ class TestFilesSerializer:
         ]
 
         manifest = serializer.serialize(sample_model_file)
-        digests = [d.digest_hex for d in manifest._digest_info.values()]
+        digests = _extract_digests_from_manifest(manifest)
 
         assert digests == expected
 
@@ -55,15 +94,11 @@ class TestFilesSerializer:
     def test_file_manifest_changes_if_content_changes(self, sample_model_file):
         serializer = itemized.FilesSerializer(self._hasher_factory)
         manifest = serializer.serialize(sample_model_file)
-        digests = set(
-            digest.digest_hex for digest in manifest._digest_info.values()
-        )
+        digests = set(_extract_digests_from_manifest(manifest))
 
         sample_model_file.write_bytes(fixtures_constants.ANOTHER_MODEL_TEXT)
         new_manifest = serializer.serialize(sample_model_file)
-        new_digests = set(
-            digest.digest_hex for digest in new_manifest._digest_info.values()
-        )
+        new_digests = set(_extract_digests_from_manifest(new_manifest))
 
         assert manifest != new_manifest
         assert digests != new_digests
@@ -72,14 +107,10 @@ class TestFilesSerializer:
     def test_directory_model_with_one_single_file(self, sample_model_file):
         serializer = itemized.FilesSerializer(self._hasher_factory)
         manifest_file = serializer.serialize(sample_model_file)
-        digests_file = set(
-            digest.digest_hex for digest in manifest_file._digest_info.values()
-        )
+        digests_file = set(_extract_digests_from_manifest(manifest_file))
 
         manifest = serializer.serialize(sample_model_file.parent)
-        digests = set(
-            digest.digest_hex for digest in manifest._digest_info.values()
-        )
+        digests = set(_extract_digests_from_manifest(manifest))
 
         assert manifest != manifest_file  # different paths
         assert digests == digests_file
@@ -102,10 +133,7 @@ class TestFilesSerializer:
         # Re-enable lint, so pylint: enable=line-too-long
 
         manifest = serializer.serialize(sample_model_folder)
-        items = {
-            str(path): digest.digest_hex
-            for path, digest in manifest._digest_info.items()
-        }
+        items = _extract_items_from_manifest(manifest)
 
         assert items == expected_items
 
@@ -125,8 +153,7 @@ class TestFilesSerializer:
         serializer = itemized.FilesSerializer(self._hasher_factory)
         manifest = serializer.serialize(sample_model_folder)
 
-        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
-        altered_dir = dirs[0]
+        altered_dir = _get_first_directory(sample_model_folder)
         new_empty_dir = altered_dir / "empty"
         new_empty_dir.mkdir()
         new_manifest = serializer.serialize(sample_model_folder)
@@ -137,8 +164,7 @@ class TestFilesSerializer:
         serializer = itemized.FilesSerializer(self._hasher_factory)
         manifest = serializer.serialize(sample_model_folder)
 
-        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
-        altered_dir = dirs[0]
+        altered_dir = _get_first_directory(sample_model_folder)
         new_empty_file = altered_dir / "empty"
         new_empty_file.write_text("")
         new_manifest = serializer.serialize(sample_model_folder)
@@ -148,29 +174,67 @@ class TestFilesSerializer:
         for path, digest in manifest._digest_info.items():
             assert new_manifest._digest_info[path] == digest
 
+    def _check_manifests_match_except_on_renamed_file(
+        self,
+        old_manifest: manifest.Manifest,
+        new_manifest: manifest.Manifest,
+        new_name: str,
+        old_name: pathlib.PurePath,
+    ):
+        """Checks that the manifests match, except on a renamed file.
+
+        For the renamed file, we still want to match the digest of the old name.
+        """
+        assert old_manifest != new_manifest
+        assert len(new_manifest._digest_info) == len(old_manifest._digest_info)
+        for path, digest in new_manifest._digest_info.items():
+            if path.name == new_name:
+                assert old_manifest._digest_info[old_name] == digest
+            else:
+                assert old_manifest._digest_info[path] == digest
+
     def test_folder_model_rename_file_only_changes_path_part(
         self, sample_model_folder
     ):
         serializer = itemized.FilesSerializer(self._hasher_factory)
         manifest = serializer.serialize(sample_model_folder)
 
-        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
-        altered_dir = dirs[0]
-        files = [f for f in altered_dir.iterdir() if f.is_file()]
-        file_to_rename = files[0]
+        altered_dir = _get_first_directory(sample_model_folder)
+        file_to_rename = _get_first_file(altered_dir)
         old_name = file_to_rename.relative_to(sample_model_folder)
         old_name = pathlib.PurePosixPath(old_name)  # canonicalize to Posix
         new_name = file_to_rename.with_name("new-file")
         file_to_rename.rename(new_name)
         new_manifest = serializer.serialize(sample_model_folder)
 
-        assert manifest != new_manifest
-        assert len(new_manifest._digest_info) == len(manifest._digest_info)
+        self._check_manifests_match_except_on_renamed_file(
+            manifest, new_manifest, "new-file", old_name
+        )
+
+    def _check_manifests_match_except_on_renamed_dir(
+        self,
+        old_manifest: manifest.Manifest,
+        new_manifest: manifest.Manifest,
+        new_name: str,
+        old_name: str,
+    ):
+        """Checks that the manifests match, minus on paths under changed dir.
+
+        For paths under the changed directory, we want to match the digest of
+        the old path.
+        """
+        assert old_manifest != new_manifest
+        assert len(new_manifest._digest_info) == len(old_manifest._digest_info)
         for path, digest in new_manifest._digest_info.items():
-            if path.name == "new-file":
-                assert manifest._digest_info[old_name] == digest
+            if new_name in path.parts:
+                parts = [
+                    old_name if part == new_name else part
+                    for part in path.parts
+                ]
+                old = pathlib.PurePosixPath(*parts)
+                assert old_manifest._digest_info[old] == digest
             else:
-                assert manifest._digest_info[path] == digest
+                assert old_manifest._digest_info[path] == digest
 
     def test_folder_model_rename_dir_only_changes_path_part(
         self, sample_model_folder
@@ -178,34 +242,22 @@ class TestFilesSerializer:
         serializer = itemized.FilesSerializer(self._hasher_factory)
         manifest = serializer.serialize(sample_model_folder)
 
-        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
-        dir_to_rename = dirs[0]
+        dir_to_rename = _get_first_directory(sample_model_folder)
         old_name = dir_to_rename.name
         new_name = dir_to_rename.with_name("new-dir")
         dir_to_rename.rename(new_name)
         new_manifest = serializer.serialize(sample_model_folder)
 
-        assert manifest != new_manifest
-        assert len(new_manifest._digest_info) == len(manifest._digest_info)
-        for path, digest in new_manifest._digest_info.items():
-            if "new-dir" in path.parts:
-                parts = [
-                    old_name if part == "new-dir" else part
-                    for part in path.parts
-                ]
-                old = pathlib.PurePosixPath(*parts)
-                assert manifest._digest_info[old] == digest
-            else:
-                assert manifest._digest_info[path] == digest
+        self._check_manifests_match_except_on_renamed_dir(
+            manifest, new_manifest, "new-dir", old_name
+        )
 
     def test_folder_model_replace_file_empty_folder(self, sample_model_folder):
         serializer = itemized.FilesSerializer(self._hasher_factory)
         manifest = serializer.serialize(sample_model_folder)
 
-        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
-        altered_dir = dirs[0]
-        files = [f for f in altered_dir.iterdir() if f.is_file()]
-        file_to_replace = files[0]
+        altered_dir = _get_first_directory(sample_model_folder)
+        file_to_replace = _get_first_file(altered_dir)
         file_to_replace.unlink()
         file_to_replace.mkdir()
         new_manifest = serializer.serialize(sample_model_folder)
@@ -215,26 +267,35 @@ class TestFilesSerializer:
         for path, digest in new_manifest._digest_info.items():
             assert manifest._digest_info[path] == digest
 
+    def _check_manifests_match_except_on_entry(
+        self,
+        old_manifest: manifest.Manifest,
+        new_manifest: manifest.Manifest,
+        expected_mismatch_path: pathlib.Path,
+    ):
+        """Checks that the manifests match, except for given path."""
+        assert old_manifest != new_manifest
+        assert len(new_manifest._digest_info) == len(old_manifest._digest_info)
+        for path, digest in new_manifest._digest_info.items():
+            if path == expected_mismatch_path:
+                assert old_manifest._digest_info[path] != digest
+            else:
+                assert old_manifest._digest_info[path] == digest
+
     def test_folder_model_change_file(self, sample_model_folder):
         serializer = itemized.FilesSerializer(self._hasher_factory)
         manifest = serializer.serialize(sample_model_folder)
 
-        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
-        altered_dir = dirs[0]
-        files = [f for f in altered_dir.iterdir() if f.is_file()]
-        file_to_change = files[0]
+        altered_dir = _get_first_directory(sample_model_folder)
+        file_to_change = _get_first_file(altered_dir)
         file_to_change.write_bytes(fixtures_constants.KNOWN_MODEL_TEXT)
         changed_entry = file_to_change.relative_to(sample_model_folder)
         changed_entry = pathlib.PurePosixPath(changed_entry)  # canonicalize
         new_manifest = serializer.serialize(sample_model_folder)
 
-        assert manifest != new_manifest
-        assert len(new_manifest._digest_info) == len(manifest._digest_info)
-        for path, digest in new_manifest._digest_info.items():
-            if path == changed_entry:
-                assert manifest._digest_info[path] != digest
-            else:
-                assert manifest._digest_info[path] == digest
+        self._check_manifests_match_except_on_entry(
+            manifest, new_manifest, changed_entry
+        )
 
     def test_deep_folder(self, deep_model_folder):
         serializer = itemized.FilesSerializer(self._hasher_factory)
@@ -248,10 +309,7 @@ class TestFilesSerializer:
         # Re-enable lint, so pylint: enable=line-too-long
 
         manifest = serializer.serialize(deep_model_folder)
-        items = {
-            str(path): digest.digest_hex
-            for path, digest in manifest._digest_info.items()
-        }
+        items = _extract_items_from_manifest(manifest)
 
         assert items == expected_items
 
@@ -262,7 +320,7 @@ class TestFilesSerializer:
         ]
 
         manifest = serializer.serialize(empty_model_file)
-        digests = [d.digest_hex for d in manifest._digest_info.values()]
+        digests = _extract_digests_from_manifest(manifest)
 
         assert digests == expected
 
@@ -274,8 +332,7 @@ class TestFilesSerializer:
     def test_special_file(self, sample_model_folder):
         serializer = itemized.FilesSerializer(self._hasher_factory)
 
-        dirs = [d for d in sample_model_folder.iterdir() if d.is_dir()]
-        altered_dir = dirs[0]
+        altered_dir = _get_first_directory(sample_model_folder)
         pipe = altered_dir / "pipe"
 
         try:

--- a/model_signing/serialization/itemized_test.py
+++ b/model_signing/serialization/itemized_test.py
@@ -28,7 +28,7 @@ from model_signing.serialization import itemized
 pytest_plugins = ("model_signing.serialization.fixtures",)
 
 
-def _extract_digests_from_manifest(manifest: manifest.Manifest) -> [str]:
+def _extract_digests_from_manifest(manifest: manifest.FileLevelManifest) -> [str]:
     """Extracts the hex digest for every subject in a manifest.
 
     Used in multiple tests to check that we obtained the expected digests.
@@ -36,7 +36,7 @@ def _extract_digests_from_manifest(manifest: manifest.Manifest) -> [str]:
     return [d.digest_hex for d in manifest._digest_info.values()]
 
 
-def _extract_items_from_manifest(manifest: manifest.Manifest) -> Dict[str, str]:
+def _extract_items_from_manifest(manifest: manifest.FileLevelManifest) -> Dict[str, str]:
     """Builds a dictionary representation of the items in a manifest.
 
     Every item is mapped to its digest.
@@ -176,8 +176,8 @@ class TestFilesSerializer:
 
     def _check_manifests_match_except_on_renamed_file(
         self,
-        old_manifest: manifest.Manifest,
-        new_manifest: manifest.Manifest,
+        old_manifest: manifest.FileLevelManifest,
+        new_manifest: manifest.FileLevelManifest,
         new_name: str,
         old_name: pathlib.PurePath,
     ):
@@ -213,8 +213,8 @@ class TestFilesSerializer:
 
     def _check_manifests_match_except_on_renamed_dir(
         self,
-        old_manifest: manifest.Manifest,
-        new_manifest: manifest.Manifest,
+        old_manifest: manifest.FileLevelManifest,
+        new_manifest: manifest.FileLevelManifest,
         new_name: str,
         old_name: str,
     ):
@@ -269,8 +269,8 @@ class TestFilesSerializer:
 
     def _check_manifests_match_except_on_entry(
         self,
-        old_manifest: manifest.Manifest,
-        new_manifest: manifest.Manifest,
+        old_manifest: manifest.FileLevelManifest,
+        new_manifest: manifest.FileLevelManifest,
         expected_mismatch_path: pathlib.PurePath,
     ):
         """Checks that the manifests match, except for given path."""

--- a/model_signing/serialization/itemized_test.py
+++ b/model_signing/serialization/itemized_test.py
@@ -29,7 +29,7 @@ pytest_plugins = ("model_signing.serialization.fixtures",)
 
 
 def _extract_digests_from_manifest(
-    manifest: manifest.FileLevelManifest,
+    manifest: manifest.FileLevelManifest | manifest.ShardLevelManifest,
 ) -> List[str]:
     """Extracts the hex digest for every subject in a manifest.
 
@@ -54,7 +54,7 @@ def _extract_items_from_manifest(
 
 
 def _extract_shard_items_from_manifest(
-    manifest: manifest.FileLevelManifest,
+    manifest: manifest.ShardLevelManifest,
 ) -> Dict[Tuple[str, str, str], str]:
     """Builds a dictionary representation of the items in a manifest.
 
@@ -547,8 +547,8 @@ class TestShardedFilesSerializer:
 
     def _check_manifests_match_except_on_renamed_file(
         self,
-        old_manifest: manifest.FileLevelManifest,
-        new_manifest: manifest.FileLevelManifest,
+        old_manifest: manifest.ShardLevelManifest,
+        new_manifest: manifest.ShardLevelManifest,
         new_name: str,
         old_name: pathlib.PurePath,
     ):
@@ -586,8 +586,8 @@ class TestShardedFilesSerializer:
 
     def _check_manifests_match_except_on_renamed_dir(
         self,
-        old_manifest: manifest.FileLevelManifest,
-        new_manifest: manifest.FileLevelManifest,
+        old_manifest: manifest.ShardLevelManifest,
+        new_manifest: manifest.ShardLevelManifest,
         new_name: str,
         old_name: str,
     ):
@@ -643,8 +643,8 @@ class TestShardedFilesSerializer:
 
     def _check_manifests_match_except_on_entry(
         self,
-        old_manifest: manifest.FileLevelManifest,
-        new_manifest: manifest.FileLevelManifest,
+        old_manifest: manifest.ShardLevelManifest,
+        new_manifest: manifest.ShardLevelManifest,
         expected_mismatch_path: pathlib.PurePath,
     ):
         """Checks that the manifests match, except for given path."""

--- a/model_signing/serialization/itemized_test.py
+++ b/model_signing/serialization/itemized_test.py
@@ -14,7 +14,7 @@
 
 import os
 import pathlib
-from typing import Dict
+from typing import Dict, List
 import pytest
 
 from model_signing.hashing import file
@@ -30,7 +30,7 @@ pytest_plugins = ("model_signing.serialization.fixtures",)
 
 def _extract_digests_from_manifest(
     manifest: manifest.FileLevelManifest,
-) -> [str]:
+) -> List[str]:
     """Extracts the hex digest for every subject in a manifest.
 
     Used in multiple tests to check that we obtained the expected digests.

--- a/model_signing/serialization/itemized_test.py
+++ b/model_signing/serialization/itemized_test.py
@@ -224,12 +224,14 @@ class TestFilesSerializer:
         files = [f for f in altered_dir.iterdir() if f.is_file()]
         file_to_change = files[0]
         file_to_change.write_bytes(fixtures_constants.KNOWN_MODEL_TEXT)
+        changed_entry = file_to_change.relative_to(sample_model_folder)
+        changed_entry = pathlib.PurePosixPath(changed_entry)  # canonicalize
         new_manifest = serializer.serialize(sample_model_folder)
 
         assert manifest != new_manifest
         assert len(new_manifest._digest_info) == len(manifest._digest_info)
         for path, digest in new_manifest._digest_info.items():
-            if path == file_to_change.relative_to(sample_model_folder):
+            if path == changed_manifest_entry:
                 assert manifest._digest_info[path] != digest
             else:
                 assert manifest._digest_info[path] == digest
@@ -491,6 +493,7 @@ class TestShardedFilesSerializer:
         files = [f for f in altered_dir.iterdir() if f.is_file()]
         file_to_rename = files[0]
         old_name = file_to_rename.relative_to(sample_model_folder)
+        old_name = pathlib.PurePosixPath(old_name)  # canonicalize to Posix
         new_name = file_to_rename.with_name("new-file")
         file_to_rename.rename(new_name)
         new_manifest = serializer.serialize(sample_model_folder)
@@ -527,7 +530,7 @@ class TestShardedFilesSerializer:
                     old_name if part == "new-dir" else part
                     for part in path.parts
                 ]
-                old = (pathlib.Path(*parts), start, end)
+                old = (pathlib.PurePosixPath(*parts), start, end)
                 assert manifest._digest_info[old] == digest
             else:
                 assert manifest._digest_info[shard] == digest
@@ -558,13 +561,15 @@ class TestShardedFilesSerializer:
         files = [f for f in altered_dir.iterdir() if f.is_file()]
         file_to_change = files[0]
         file_to_change.write_bytes(fixtures_constants.KNOWN_MODEL_TEXT)
+        changed_entry = file_to_change.relative_to(sample_model_folder)
+        changed_entry = pathlib.PurePosixPath(changed_entry)  # canonicalize
         new_manifest = serializer.serialize(sample_model_folder)
 
         assert manifest != new_manifest
         assert len(new_manifest._digest_info) == len(manifest._digest_info)
         for shard, digest in new_manifest._digest_info.items():
             path, _, _ = shard
-            if path == file_to_change.relative_to(sample_model_folder):
+            if path == changed_manifest_entry:
                 # Note that the file size changes
                 assert manifest._digest_info[(path, 0, 23)] != digest
             else:

--- a/model_signing/serialization/itemized_test.py
+++ b/model_signing/serialization/itemized_test.py
@@ -231,7 +231,7 @@ class TestFilesSerializer:
         assert manifest != new_manifest
         assert len(new_manifest._digest_info) == len(manifest._digest_info)
         for path, digest in new_manifest._digest_info.items():
-            if path == changed_manifest_entry:
+            if path == changed_entry:
                 assert manifest._digest_info[path] != digest
             else:
                 assert manifest._digest_info[path] == digest
@@ -569,7 +569,7 @@ class TestShardedFilesSerializer:
         assert len(new_manifest._digest_info) == len(manifest._digest_info)
         for shard, digest in new_manifest._digest_info.items():
             path, _, _ = shard
-            if path == changed_manifest_entry:
+            if path == changed_entry:
                 # Note that the file size changes
                 assert manifest._digest_info[(path, 0, 23)] != digest
             else:

--- a/model_signing/serialization/itemized_test.py
+++ b/model_signing/serialization/itemized_test.py
@@ -271,7 +271,7 @@ class TestFilesSerializer:
         self,
         old_manifest: manifest.Manifest,
         new_manifest: manifest.Manifest,
-        expected_mismatch_path: pathlib.Path,
+        expected_mismatch_path: pathlib.PurePath,
     ):
         """Checks that the manifests match, except for given path."""
         assert old_manifest != new_manifest

--- a/model_signing/serialization/itemized_test.py
+++ b/model_signing/serialization/itemized_test.py
@@ -17,9 +17,7 @@ import pathlib
 import pytest
 
 from model_signing.hashing import file
-from model_signing.hashing import hashing
 from model_signing.hashing import memory
-from model_signing.manifest import manifest
 from model_signing.serialization import fixtures_constants
 from model_signing.serialization import itemized
 

--- a/model_signing/serialization/itemized_test.py
+++ b/model_signing/serialization/itemized_test.py
@@ -28,7 +28,9 @@ from model_signing.serialization import itemized
 pytest_plugins = ("model_signing.serialization.fixtures",)
 
 
-def _extract_digests_from_manifest(manifest: manifest.FileLevelManifest) -> [str]:
+def _extract_digests_from_manifest(
+    manifest: manifest.FileLevelManifest,
+) -> [str]:
     """Extracts the hex digest for every subject in a manifest.
 
     Used in multiple tests to check that we obtained the expected digests.
@@ -36,7 +38,9 @@ def _extract_digests_from_manifest(manifest: manifest.FileLevelManifest) -> [str
     return [d.digest_hex for d in manifest._digest_info.values()]
 
 
-def _extract_items_from_manifest(manifest: manifest.FileLevelManifest) -> Dict[str, str]:
+def _extract_items_from_manifest(
+    manifest: manifest.FileLevelManifest,
+) -> Dict[str, str]:
     """Builds a dictionary representation of the items in a manifest.
 
     Every item is mapped to its digest.


### PR DESCRIPTION
#### Summary
Adds machinery for manifests that list components of the model paired with their digests. Currently supporting per file and per file shard listings, to migrate existing `serialize_v0` and `serialize_v1` functionality.

For now, we just store the manifest in memory and we don't yet support signing it. There is only one (long) comment on how all of this is planned to work, future PRs should arrive with the next functionality.

A diagram of all the classes so far:

![image](https://github.com/sigstore/model-transparency/assets/323199/a0569bbd-f8ad-4b7b-9ff0-f1a71f4aa880)

Next steps involve adding the ability to serialize the manifest to disk and sign it. Then, parsing a signed manifest from disk to verify models. Then the streaming APIs. And, of course, some benchmarks, cleanup, etc., that comes in parallel.

#### Release Note
NONE

#### Documentation
NONE