### PR TITLE
Add support for `hashlib.file_digest`.

### DIFF
--- a/model_signing/hashing/file.py
+++ b/model_signing/hashing/file.py
@@ -48,6 +48,7 @@ Example usage for `OpenedFileHasher`:
 
 import hashlib
 import pathlib
+from typing import BinaryIO
 from typing_extensions import override
 
 from model_signing.hashing import hashing
@@ -154,12 +155,13 @@ class OpenedFileHasher(FileHasher):
 
     def __init__(
         self,
-        file_descriptor: "hashlib._BytesIOLike | hashlib._FileDigestFileObj",
+        # https://github.com/python/typeshed/issues/2166
+        file_descriptor: BinaryIO,
         *,
         algorithm: str = "sha256",
         digest_name_override: str | None = None,
     ):
-        """Initializes an instance to hash a file with a specific `HashEngine`.
+        """Initializes an instance to hash a file with a specific algorithm.
 
         Args:
             file_descriptor: Descriptor to the opened file.
@@ -174,7 +176,8 @@ class OpenedFileHasher(FileHasher):
 
     def set_file_descriptor(
         self,
-        file_descriptor: "hashlib._BytesIOLike | hashlib._FileDigestFileObj",
+        # https://github.com/python/typeshed/issues/2166
+        file_descriptor: BinaryIO,
     ) -> None:
         """Redefines the file_descriptor to be hashed in `compute`."""
         self._fd = file_descriptor
@@ -188,7 +191,10 @@ class OpenedFileHasher(FileHasher):
 
     @override
     def compute(self) -> hashing.Digest:
+        # https://github.com/python/typeshed/issues/2166
+        # pytype: disable=wrong-arg-types
         digest = hashlib.file_digest(self._fd, self._algorithm)
+        # pytype: enable=wrong-arg-types
         return hashing.Digest(self.digest_name, digest.digest())
 
     @property

--- a/model_signing/hashing/file.py
+++ b/model_signing/hashing/file.py
@@ -56,15 +56,9 @@ from model_signing.hashing import hashing
 class FileHasher(hashing.HashEngine):
     """Generic file hash engine.
 
-    The `digest_name()` method MUST record all parameters that influence the
-    hash output. For example, if a file is split into shards which are hashed
-    separately and the final digest value is computed by aggregating these
-    hashes, then the shard size must be given in the output string. However, for
-    simplicity, predefined names can be used to override the `digest_name()`
-    output.
-
     This class is intentionally empty (and abstract, via inheritance) to be used
-    only as a type annotation.
+    only as a type annotation (to signal that API expects a hasher capable of
+    hashing files, instead of any `HashEngine` instance).
     """
 
     pass

--- a/model_signing/hashing/file.py
+++ b/model_signing/hashing/file.py
@@ -14,11 +14,11 @@
 
 """Machinery for computing digests for a single file.
 
-Example usage for `FileHasher`:
+Example usage for `SimpleFileHasher`:
 ```python
 >>> with open("/tmp/file", "w") as f:
 ...     f.write("abcd")
->>> hasher = FileHasher("/tmp/file", SHA256())
+>>> hasher = SimpleFileHasher("/tmp/file", SHA256())
 >>> digest = hasher.compute()
 >>> digest.digest_hex
 '88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589'
@@ -33,8 +33,20 @@ Example usage for `ShardedFileHasher`, reading only the second part of a file:
 >>> digest.digest_hex
 '88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589'
 ```
+
+Example usage for `OpenedFileHasher`:
+```python
+>>> with open("/tmp/file", "w") as f:
+...     f.write("abcd")
+>>> with open("/tmp/file", "rb") as f:
+...     hasher = OpenedFileHasher(f)
+...     digest = hasher.compute()
+>>> digest.digest_hex
+'88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589'
+```
 """
 
+import hashlib
 import pathlib
 from typing_extensions import override
 
@@ -44,19 +56,29 @@ from model_signing.hashing import hashing
 class FileHasher(hashing.HashEngine):
     """Generic file hash engine.
 
-    To compute the hash of a file, we read the file exactly once, including for
-    very large files that don't fit in memory. Files are read in chunks and each
-    chunk is passed to the `update` method of an inner
-    `hashing.StreamingHashEngine`, instance. This ensures that the file digest
-    will not change even if the chunk size changes. As such, we can dynamically
-    determine an optimal value for the chunk argument.
-
     The `digest_name()` method MUST record all parameters that influence the
     hash output. For example, if a file is split into shards which are hashed
     separately and the final digest value is computed by aggregating these
     hashes, then the shard size must be given in the output string. However, for
     simplicity, predefined names can be used to override the `digest_name()`
     output.
+
+    This class is intentionally empty (and abstract, via inheritance) to be used
+    only as a type annotation.
+    """
+
+    pass
+
+
+class SimpleFileHasher(FileHasher):
+    """Simple file hash engine that computes the digest iteratively.
+
+    To compute the hash of a file, we read the file exactly once, including for
+    very large files that don't fit in memory. Files are read in chunks and each
+    chunk is passed to the `update` method of an inner
+    `hashing.StreamingHashEngine`, instance. This ensures that the file digest
+    will not change even if the chunk size changes. As such, we can dynamically
+    determine an optimal value for the chunk argument.
     """
 
     def __init__(
@@ -93,8 +115,8 @@ class FileHasher(hashing.HashEngine):
         """Redefines the file to be hashed in `compute`."""
         self._file = file
 
-    @override
     @property
+    @override
     def digest_name(self) -> str:
         if self._digest_name_override is not None:
             return self._digest_name_override
@@ -118,14 +140,71 @@ class FileHasher(hashing.HashEngine):
         digest = self._content_hasher.compute()
         return hashing.Digest(self.digest_name, digest.digest_value)
 
-    @override
     @property
+    @override
     def digest_size(self) -> int:
         """The size, in bytes, of the digests produced by the engine."""
         return self._content_hasher.digest_size
 
 
-class ShardedFileHasher(FileHasher):
+class OpenedFileHasher(FileHasher):
+    """File hasher using `hashlib.file_digest` to operate on opened files.
+
+    This also supports other file-like objects opened for reading in binary
+    mode, e.g., BytesIO, SocketIO.
+
+    Since the `hashlib.file_digest` may bypass Python's I/O, this could be
+    faster than `SimpleFileHasher`, at the cost of having the file descriptor
+    maintained by the caller, according to `hashlib.file_digest` requirements.
+    """
+
+    def __init__(
+        self,
+        file_descriptor: "hashlib._BytesIOLike | hashlib._FileDigestFileObj",
+        *,
+        algorithm: str = "sha256",
+        digest_name_override: str | None = None,
+    ):
+        """Initializes an instance to hash a file with a specific `HashEngine`.
+
+        Args:
+            file_descriptor: Descriptor to the opened file.
+            algorithm: a hashing algorithm that can be passed as argument to
+              `hashlib.new`. By default, this is "sha256".
+            digest_name_override: Optional string to allow overriding the
+              `digest_name` property to support shorter, standardized names.
+        """
+        self._fd = file_descriptor
+        self._algorithm = algorithm
+        self._digest_name_override = digest_name_override
+
+    def set_file_descriptor(
+        self,
+        file_descriptor: "hashlib._BytesIOLike | hashlib._FileDigestFileObj",
+    ) -> None:
+        """Redefines the file_descriptor to be hashed in `compute`."""
+        self._fd = file_descriptor
+
+    @property
+    @override
+    def digest_name(self) -> str:
+        if self._digest_name_override is not None:
+            return self._digest_name_override
+        return f"file-fd-{self._algorithm}"
+
+    @override
+    def compute(self) -> hashing.Digest:
+        digest = hashlib.file_digest(self._fd, self._algorithm)
+        return hashing.Digest(self.digest_name, digest.digest())
+
+    @property
+    @override
+    def digest_size(self) -> int:
+        """The size, in bytes, of the digests produced by the engine."""
+        return hashlib.new(self._algorithm).digest_size
+
+
+class ShardedFileHasher(SimpleFileHasher):
     """File hash engine that can be invoked in parallel.
 
     To efficiently support hashing large files, this class provides an ability
@@ -220,8 +299,8 @@ class ShardedFileHasher(FileHasher):
         digest = self._content_hasher.compute()
         return hashing.Digest(self.digest_name, digest.digest_value)
 
-    @override
     @property
+    @override
     def digest_name(self) -> str:
         if self._digest_name_override is not None:
             return self._digest_name_override

--- a/model_signing/hashing/file_test.py
+++ b/model_signing/hashing/file_test.py
@@ -418,33 +418,64 @@ class TestOpenedFileHasher:
 
     def test_hash_of_known_file(self, sample_file, expected_digest):
         with open(sample_file, "rb") as f:
+            # https://github.com/python/typeshed/issues/2166
+            # pytype: disable=wrong-arg-types
             hasher = file.OpenedFileHasher(f)
+            # pytype: enable=wrong-arg-types
+            digest = hasher.compute()
+
+        assert digest.digest_hex == expected_digest
+
+    def test_set_file_descriptor(self, sample_file, expected_digest):
+        with open(sample_file, "rb") as f:
+            # https://github.com/python/typeshed/issues/2166
+            # pytype: disable=wrong-arg-types
+            hasher = file.OpenedFileHasher(f)
+            # pytype: enable=wrong-arg-types
+
+        with open(sample_file, "rb") as f:
+            # https://github.com/python/typeshed/issues/2166
+            # pytype: disable=wrong-arg-types
+            hasher.set_file_descriptor(f)
+            # pytype: enable=wrong-arg-types
             digest = hasher.compute()
 
         assert digest.digest_hex == expected_digest
 
     def test_default_digest_name(self, sample_file):
         with open(sample_file, "rb") as f:
+            # https://github.com/python/typeshed/issues/2166
+            # pytype: disable=wrong-arg-types
             hasher = file.OpenedFileHasher(f)
+            # pytype: enable=wrong-arg-types
 
         assert hasher.digest_name == "file-fd-sha256"
 
     def test_override_digest_name(self, sample_file):
         with open(sample_file, "rb") as f:
+            # https://github.com/python/typeshed/issues/2166
+            # pytype: disable=wrong-arg-types
             hasher = file.OpenedFileHasher(f, digest_name_override="test-hash")
+            # pytype: enable=wrong-arg-types
 
         assert hasher.digest_name == "test-hash"
 
     def test_digest_algorithm_is_digest_name(self, sample_file):
         with open(sample_file, "rb") as f:
+            # https://github.com/python/typeshed/issues/2166
+            # pytype: disable=wrong-arg-types
             hasher = file.OpenedFileHasher(f)
+            # pytype: enable=wrong-arg-types
             digest = hasher.compute()
 
         assert digest.algorithm == hasher.digest_name
 
     def test_digest_size(self, sample_file):
         with open(sample_file, "rb") as f:
+            # https://github.com/python/typeshed/issues/2166
+            # pytype: disable=wrong-arg-types
             hasher = file.OpenedFileHasher(f)
+            # pytype: enable=wrong-arg-types
 
         memory_hasher = memory.SHA256()
         assert hasher.digest_size == memory_hasher.digest_size

--- a/model_signing/hashing/file_test.py
+++ b/model_signing/hashing/file_test.py
@@ -418,64 +418,43 @@ class TestOpenedFileHasher:
 
     def test_hash_of_known_file(self, sample_file, expected_digest):
         with open(sample_file, "rb") as f:
-            # https://github.com/python/typeshed/issues/2166
-            # pytype: disable=wrong-arg-types
             hasher = file.OpenedFileHasher(f)
-            # pytype: enable=wrong-arg-types
             digest = hasher.compute()
 
         assert digest.digest_hex == expected_digest
 
     def test_set_file_descriptor(self, sample_file, expected_digest):
         with open(sample_file, "rb") as f:
-            # https://github.com/python/typeshed/issues/2166
-            # pytype: disable=wrong-arg-types
             hasher = file.OpenedFileHasher(f)
-            # pytype: enable=wrong-arg-types
 
         with open(sample_file, "rb") as f:
-            # https://github.com/python/typeshed/issues/2166
-            # pytype: disable=wrong-arg-types
             hasher.set_file_descriptor(f)
-            # pytype: enable=wrong-arg-types
             digest = hasher.compute()
 
         assert digest.digest_hex == expected_digest
 
     def test_default_digest_name(self, sample_file):
         with open(sample_file, "rb") as f:
-            # https://github.com/python/typeshed/issues/2166
-            # pytype: disable=wrong-arg-types
             hasher = file.OpenedFileHasher(f)
-            # pytype: enable=wrong-arg-types
 
         assert hasher.digest_name == "file-fd-sha256"
 
     def test_override_digest_name(self, sample_file):
         with open(sample_file, "rb") as f:
-            # https://github.com/python/typeshed/issues/2166
-            # pytype: disable=wrong-arg-types
             hasher = file.OpenedFileHasher(f, digest_name_override="test-hash")
-            # pytype: enable=wrong-arg-types
 
         assert hasher.digest_name == "test-hash"
 
     def test_digest_algorithm_is_digest_name(self, sample_file):
         with open(sample_file, "rb") as f:
-            # https://github.com/python/typeshed/issues/2166
-            # pytype: disable=wrong-arg-types
             hasher = file.OpenedFileHasher(f)
-            # pytype: enable=wrong-arg-types
             digest = hasher.compute()
 
         assert digest.algorithm == hasher.digest_name
 
     def test_digest_size(self, sample_file):
         with open(sample_file, "rb") as f:
-            # https://github.com/python/typeshed/issues/2166
-            # pytype: disable=wrong-arg-types
             hasher = file.OpenedFileHasher(f)
-            # pytype: enable=wrong-arg-types
 
         memory_hasher = memory.SHA256()
         assert hasher.digest_size == memory_hasher.digest_size

--- a/model_signing/hashing/file_test.py
+++ b/model_signing/hashing/file_test.py
@@ -64,55 +64,61 @@ def expected_content_digest():
     return digest.digest_hex
 
 
-class TestFileHasher:
+class TestSimpleFileHasher:
 
     def test_fails_with_negative_chunk_size(self):
         with pytest.raises(ValueError, match="Chunk size must be non-negative"):
-            file.FileHasher(_UNUSED_PATH, memory.SHA256(), chunk_size=-2)
+            file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256(), chunk_size=-2)
 
     def test_hash_of_known_file(self, sample_file, expected_digest):
-        hasher = file.FileHasher(sample_file, memory.SHA256())
+        hasher = file.SimpleFileHasher(sample_file, memory.SHA256())
         digest = hasher.compute()
         assert digest.digest_hex == expected_digest
 
     def test_hash_of_known_file_no_chunk(self, sample_file, expected_digest):
-        hasher = file.FileHasher(sample_file, memory.SHA256(), chunk_size=0)
+        hasher = file.SimpleFileHasher(
+            sample_file, memory.SHA256(), chunk_size=0
+        )
         digest = hasher.compute()
         assert digest.digest_hex == expected_digest
 
     def test_hash_of_known_file_small_chunk(self, sample_file, expected_digest):
-        hasher = file.FileHasher(sample_file, memory.SHA256(), chunk_size=2)
+        hasher = file.SimpleFileHasher(
+            sample_file, memory.SHA256(), chunk_size=2
+        )
         digest = hasher.compute()
         assert digest.digest_hex == expected_digest
 
     def test_hash_of_known_file_large_chunk(self, sample_file, expected_digest):
         size = 2 * len(_FULL_CONTENT)
-        hasher = file.FileHasher(sample_file, memory.SHA256(), chunk_size=size)
+        hasher = file.SimpleFileHasher(
+            sample_file, memory.SHA256(), chunk_size=size
+        )
         digest = hasher.compute()
         assert digest.digest_hex == expected_digest
 
     def test_hash_file_twice(self, sample_file):
-        hasher1 = file.FileHasher(sample_file, memory.SHA256())
+        hasher1 = file.SimpleFileHasher(sample_file, memory.SHA256())
         digest1 = hasher1.compute()
-        hasher2 = file.FileHasher(sample_file, memory.SHA256())
+        hasher2 = file.SimpleFileHasher(sample_file, memory.SHA256())
         digest2 = hasher2.compute()
         assert digest1.digest_value == digest2.digest_value
 
     def test_hash_file_twice_same_hasher(self, sample_file):
-        hasher = file.FileHasher(sample_file, memory.SHA256())
+        hasher = file.SimpleFileHasher(sample_file, memory.SHA256())
         digest1 = hasher.compute()
         digest2 = hasher.compute()
         assert digest1.digest_value == digest2.digest_value
 
     def test_hash_file_twice_same_hasher_reset_file(self, sample_file):
-        hasher = file.FileHasher(sample_file, memory.SHA256())
+        hasher = file.SimpleFileHasher(sample_file, memory.SHA256())
         digest1 = hasher.compute()
         hasher.set_file(sample_file)
         digest2 = hasher.compute()
         assert digest1.digest_value == digest2.digest_value
 
     def test_set_file(self, sample_file, sample_file_content_only):
-        hasher = file.FileHasher(sample_file, memory.SHA256())
+        hasher = file.SimpleFileHasher(sample_file, memory.SHA256())
         digest1 = hasher.compute()
         hasher.set_file(sample_file_content_only)
         _ = hasher.compute()
@@ -121,11 +127,11 @@ class TestFileHasher:
         assert digest1.digest_value == digest2.digest_value
 
     def test_default_digest_name(self):
-        hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         assert hasher.digest_name == "file-sha256"
 
     def test_override_digest_name(self):
-        hasher = file.FileHasher(
+        hasher = file.SimpleFileHasher(
             _UNUSED_PATH,
             memory.SHA256(),
             chunk_size=10,
@@ -134,13 +140,13 @@ class TestFileHasher:
         assert hasher.digest_name == "test-hash"
 
     def test_digest_algorithm_is_digest_name(self, sample_file):
-        hasher = file.FileHasher(sample_file, memory.SHA256())
+        hasher = file.SimpleFileHasher(sample_file, memory.SHA256())
         digest = hasher.compute()
         assert digest.algorithm == hasher.digest_name
 
     def test_digest_size(self):
         memory_hasher = memory.SHA256()
-        hasher = file.FileHasher(sample_file, memory_hasher)
+        hasher = file.SimpleFileHasher(sample_file, memory_hasher)
         assert hasher.digest_size == memory_hasher.digest_size
 
 
@@ -402,5 +408,7 @@ class TestShardedFileHasher:
 
     def test_digest_size(self):
         memory_hasher = memory.SHA256()
-        hasher = file.FileHasher(sample_file, memory_hasher)
+        hasher = file.ShardedFileHasher(
+            sample_file, memory_hasher, start=0, end=2
+        )
         assert hasher.digest_size == memory_hasher.digest_size

--- a/model_signing/hashing/file_test.py
+++ b/model_signing/hashing/file_test.py
@@ -412,3 +412,39 @@ class TestShardedFileHasher:
             sample_file, memory_hasher, start=0, end=2
         )
         assert hasher.digest_size == memory_hasher.digest_size
+
+
+class TestOpenedFileHasher:
+
+    def test_hash_of_known_file(self, sample_file, expected_digest):
+        with open(sample_file, "rb") as f:
+            hasher = file.OpenedFileHasher(f)
+            digest = hasher.compute()
+
+        assert digest.digest_hex == expected_digest
+
+    def test_default_digest_name(self, sample_file):
+        with open(sample_file, "rb") as f:
+            hasher = file.OpenedFileHasher(f)
+
+        assert hasher.digest_name == "file-fd-sha256"
+
+    def test_override_digest_name(self, sample_file):
+        with open(sample_file, "rb") as f:
+            hasher = file.OpenedFileHasher(f, digest_name_override="test-hash")
+
+        assert hasher.digest_name == "test-hash"
+
+    def test_digest_algorithm_is_digest_name(self, sample_file):
+        with open(sample_file, "rb") as f:
+            hasher = file.OpenedFileHasher(f)
+            digest = hasher.compute()
+
+        assert digest.algorithm == hasher.digest_name
+
+    def test_digest_size(self, sample_file):
+        with open(sample_file, "rb") as f:
+            hasher = file.OpenedFileHasher(f)
+
+        memory_hasher = memory.SHA256()
+        assert hasher.digest_size == memory_hasher.digest_size

--- a/model_signing/hashing/memory.py
+++ b/model_signing/hashing/memory.py
@@ -59,13 +59,13 @@ class SHA256(hashing.StreamingHashEngine):
     def compute(self) -> hashing.Digest:
         return hashing.Digest(self.digest_name, self._hasher.digest())
 
-    @override
     @property
+    @override
     def digest_name(self) -> str:
         return "sha256"
 
-    @override
     @property
+    @override
     def digest_size(self) -> int:
         return self._hasher.digest_size
 
@@ -93,12 +93,12 @@ class BLAKE2(hashing.StreamingHashEngine):
     def compute(self) -> hashing.Digest:
         return hashing.Digest(self.digest_name, self._hasher.digest())
 
-    @override
     @property
+    @override
     def digest_name(self) -> str:
         return "blake2b"
 
-    @override
     @property
+    @override
     def digest_size(self) -> int:
         return self._hasher.digest_size

--- a/model_signing/hashing/precomputed.py
+++ b/model_signing/hashing/precomputed.py
@@ -45,13 +45,13 @@ class PrecomputedDigest(hashing.HashEngine):
     def compute(self) -> hashing.Digest:
         return hashing.Digest(self._digest_type, self._digest_value)
 
-    @override
     @property
+    @override
     def digest_name(self) -> str:
         return self._digest_type
 
-    @override
     @property
+    @override
     def digest_size(self) -> int:
         """The size, in bytes, of the digests produced by the engine."""
         return len(self._digest_value)

--- a/model_signing/serialization/dfs.py
+++ b/model_signing/serialization/dfs.py
@@ -97,7 +97,7 @@ class DFSSerializer(serialization.Serializer):
 
     def __init__(
         self,
-        file_hasher: file.FileHasher,
+        file_hasher: file.SimpleFileHasher,
         merge_hasher_factory: Callable[[], hashing.StreamingHashEngine],
     ):
         """Initializes an instance to serialize a model with this serializer.

--- a/model_signing/serialization/dfs_test.py
+++ b/model_signing/serialization/dfs_test.py
@@ -31,7 +31,7 @@ _UNUSED_PATH = pathlib.Path("unused")
 class TestDFSSerializer:
 
     def test_known_file(self, sample_model_file):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         manifest = serializer.serialize(sample_model_file)
         expected = (
@@ -40,14 +40,14 @@ class TestDFSSerializer:
         assert manifest.digest.digest_hex == expected
 
     def test_file_hash_is_same_as_hash_of_content(self, sample_model_file):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         manifest = serializer.serialize(sample_model_file)
         digest = memory.SHA256(fixtures_constants.KNOWN_MODEL_TEXT).compute()
         assert manifest.digest.digest_hex == digest.digest_hex
 
     def test_file_model_hash_is_same_if_model_is_moved(self, sample_model_file):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         manifest = serializer.serialize(sample_model_file)
 
@@ -60,7 +60,7 @@ class TestDFSSerializer:
     def test_file_model_hash_changes_if_content_changes(
         self, sample_model_file
     ):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         manifest = serializer.serialize(sample_model_file)
 
@@ -71,7 +71,7 @@ class TestDFSSerializer:
         assert manifest.digest.digest_value != new_manifest.digest.digest_value
 
     def test_directory_model_with_only_known_file(self, sample_model_file):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
 
         model = sample_model_file.parent
@@ -86,7 +86,7 @@ class TestDFSSerializer:
         assert manifest.digest.digest_hex != digest.digest_hex
 
     def test_known_folder(self, sample_model_folder):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         manifest = serializer.serialize(sample_model_folder)
         expected = (
@@ -97,7 +97,7 @@ class TestDFSSerializer:
     def test_folder_model_hash_is_same_if_model_is_moved(
         self, sample_model_folder
     ):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         manifest = serializer.serialize(sample_model_folder)
 
@@ -108,7 +108,7 @@ class TestDFSSerializer:
         assert manifest == new_manifest
 
     def test_empty_file(self, empty_model_file):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         manifest = serializer.serialize(empty_model_file)
         expected = (
@@ -117,7 +117,7 @@ class TestDFSSerializer:
         assert manifest.digest.digest_hex == expected
 
     def test_directory_model_with_only_empty_file(self, empty_model_file):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         manifest = serializer.serialize(empty_model_file)
         model = empty_model_file.parent
@@ -128,7 +128,7 @@ class TestDFSSerializer:
         assert manifest.digest.digest_hex == expected
 
     def test_empty_folder(self, empty_model_folder):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         manifest = serializer.serialize(empty_model_folder)
         expected = (
@@ -139,7 +139,7 @@ class TestDFSSerializer:
     def test_empty_folder_hashes_the_same_as_empty_file(
         self, empty_model_file, empty_model_folder
     ):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         folder_manifest = serializer.serialize(empty_model_folder)
         file_manifest = serializer.serialize(empty_model_file)
@@ -148,7 +148,7 @@ class TestDFSSerializer:
         )
 
     def test_folder_model_empty_entry(self, sample_model_folder):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
 
         # Alter first directory within the model
@@ -168,7 +168,7 @@ class TestDFSSerializer:
         assert manifest1.digest != manifest2.digest
 
     def test_folder_model_rename_file(self, sample_model_folder):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         manifest1 = serializer.serialize(sample_model_folder)
 
@@ -187,7 +187,7 @@ class TestDFSSerializer:
         assert manifest1.digest != manifest2.digest
 
     def test_folder_model_rename_dir(self, sample_model_folder):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         manifest1 = serializer.serialize(sample_model_folder)
 
@@ -202,7 +202,7 @@ class TestDFSSerializer:
         assert manifest1.digest != manifest2.digest
 
     def test_folder_model_replace_file_empty_folder(self, sample_model_folder):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         manifest1 = serializer.serialize(sample_model_folder)
 
@@ -220,7 +220,7 @@ class TestDFSSerializer:
         assert manifest1.digest != manifest2.digest
 
     def test_folder_model_change_file(self, sample_model_folder):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         manifest1 = serializer.serialize(sample_model_folder)
 
@@ -237,7 +237,7 @@ class TestDFSSerializer:
         assert manifest1.digest != manifest2.digest
 
     def test_deep_folder(self, deep_model_folder):
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
         manifest = serializer.serialize(deep_model_folder)
         expected = (
@@ -259,7 +259,7 @@ class TestDFSSerializer:
             # On Windows, `os.mkfifo` does not exist (it should not).
             return  # trivially pass the test
 
-        file_hasher = file.FileHasher(_UNUSED_PATH, memory.SHA256())
+        file_hasher = file.SimpleFileHasher(_UNUSED_PATH, memory.SHA256())
         serializer = dfs.DFSSerializer(file_hasher, memory.SHA256)
 
         with pytest.raises(

--- a/model_signing/serialization/itemized_test.py
+++ b/model_signing/serialization/itemized_test.py
@@ -87,7 +87,7 @@ def _get_first_file(path: pathlib.Path) -> pathlib.Path:
 class TestFilesSerializer:
 
     def _hasher_factory(self, path: pathlib.Path) -> file.FileHasher:
-        return file.FileHasher(path, memory.SHA256())
+        return file.SimpleFileHasher(path, memory.SHA256())
 
     def test_known_file(self, sample_model_file):
         serializer = itemized.FilesSerializer(self._hasher_factory)


### PR DESCRIPTION
#### Summary
This should hash files without going via Python's I/O, but requires caller to open the file descriptor in advance and close it afterwards.

For now, rather than putting the file descriptor open/close inside the class, we're leaving it to the caller, as this could be used to benefit while serializing a model, or while reading the model from a cloud filesystem (I think).

Will include this method in the benchmarks, but I'm waiting for #230 and a similar one that would use `hashlib.file_digest` for making a manifest of a model before I can do benchmarks for models that are more than just a file.

I needed to do several renames to make sure API stays the same. I also fixed a test that was testing the wrong class.

#### Release Note
NONE

#### Documentation
NONE