### PR TITLE
Revert "Chore: Remove hardcoded author/commiter from pin-deps"

### DIFF
--- a/.github/workflows/pin_deps.yml
+++ b/.github/workflows/pin_deps.yml
@@ -113,5 +113,7 @@ jobs:
       with:
         title: "Update frozen python dependencies"
         commit-message: "Bump frozen dependencies"
+        committer: "Mihai Maruseac (automated) <mihaimaruseac@google.com>"
+        author: "Mihai Maruseac (automated) <mihaimaruseac@google.com>"
         signoff: true
         delete-branch: true


### PR DESCRIPTION
Reverts sigstore/model-transparency#151

Reverting because it seems right now the dependency update PRs only run DCO check as presubmit instead of all the CI. The check deps step is run post submit, so we don't have breakages introduced (so far), but it would be nicer to run it as presubmit.

This is testing, we'll see next week if this fixes things or not (and we need further actions).

See also: https://github.com/sigstore/model-transparency/pull/238#issuecomment-2231201092