### PR TITLE
Add signing and verification  CLI scripts.

### DIFF
--- a/src/model_signing/model.py
+++ b/src/model_signing/model.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import pathlib
-from typing import Callable, TypeAlias, Iterable
+from typing import Callable, Iterable, TypeAlias
 
 from model_signing.manifest import manifest
 from model_signing.serialization import serialization

--- a/src/model_signing/model.py
+++ b/src/model_signing/model.py
@@ -1,0 +1,79 @@
+# Copyright 2024 The Sigstore Authors
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+from typing import Callable, TypeAlias, Iterable
+
+from model_signing.manifest import manifest
+from model_signing.serialization import serialization
+from model_signing.signature import verifying
+from model_signing.signing import signing
+
+
+PayloadGeneratorFunc: TypeAlias = Callable[
+    [manifest.Manifest], signing.SigningPayload
+]
+
+
+def sign(
+    model_path: pathlib.Path,
+    signer: signing.Signer,
+    payload_generator: PayloadGeneratorFunc,
+    serializer: serialization.Serializer,
+    ignore_paths: Iterable[pathlib.Path] = frozenset(),
+) -> signing.Signature:
+    """Provides a wrapper function for the steps necessary to sign a model.
+
+    Args:
+        model_path: the model to be signed.
+        signer: the signer to be used.
+        payload_generator: funtion to generate the manifest.
+        serializer: the serializer to be used for the model.
+        ignore_paths: paths that should be ignored during serialization.
+          Defaults to an empty set.
+
+    Returns:
+        The model's signature.
+    """
+    manifest = serializer.serialize(model_path, ignore_paths=ignore_paths)
+    payload = payload_generator(manifest)
+    sig = signer.sign(payload)
+    return sig
+
+
+def verify(
+    sig: signing.Signature,
+    verifier: signing.Verifier,
+    model_path: pathlib.Path,
+    serializer: serialization.Serializer,
+    ignore_paths: Iterable[pathlib.Path] = frozenset(),
+):
+    """Provides a simple wrapper to verify models.
+
+    Args:
+        sig: the signature to be verified.
+        verifier: the verifier to verify the signature.
+        model_path: the path to the model to compare manifests.
+        serializer: the serializer used to generate the local manifest.
+        ignore_paths: paths that should be ignored during serialization.
+          Defaults to an empty set.
+
+    Raises:
+        verifying.VerificationError: on any verification error.
+    """
+    peer_manifest = verifier.verify(sig)
+    local_manifest = serializer.serialize(model_path, ignore_paths=ignore_paths)
+    if peer_manifest != local_manifest:
+        raise verifying.VerificationError("the manifests do not match")

--- a/src/model_signing/signing/in_toto_signature.py
+++ b/src/model_signing/signing/in_toto_signature.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Support for signing intoto payloads into sigstore bundles."""
+
+import json
+import pathlib
+from typing import Self
+
+from sigstore_protobuf_specs.dev.sigstore.bundle import v1 as bundle_pb
+from typing_extensions import override
+
+from model_signing.manifest import manifest as manifest_module
+from model_signing.signature import signing as signature_signing
+from model_signing.signature import verifying as signature_verifying
+from model_signing.signing import in_toto
+from model_signing.signing import signing
+
+
+class IntotoSignature(signing.Signature):
+    def __init__(self, bundle: bundle_pb.Bundle):
+        self._bundle = bundle
+
+    @override
+    def write(self, path: pathlib.Path) -> None:
+        path.write_text(self._bundle.to_json())
+
+    @classmethod
+    @override
+    def read(cls, path: pathlib.Path) -> Self:
+        bundle = bundle_pb.Bundle().from_json(path.read_text())
+        return cls(bundle)
+
+    def to_manifest(self) -> manifest_module.Manifest:
+        payload = json.loads(self._bundle.dsse_envelope.payload)
+        return in_toto.IntotoPayload.manifest_from_payload(payload)
+
+
+class IntotoSigner(signing.Signer):
+    def __init__(self, sig_signer: signature_signing.Signer):
+        self._sig_signer = sig_signer
+
+    @override
+    def sign(self, payload: signing.SigningPayload) -> IntotoSignature:
+        if not isinstance(payload, in_toto.IntotoPayload):
+            raise TypeError("only IntotoPayloads are supported")
+        bundle = self._sig_signer.sign(payload.statement)
+        return IntotoSignature(bundle)
+
+
+class IntotoVerifier(signing.Verifier):
+    def __init__(self, sig_verifier: signature_verifying.Verifier):
+        self._sig_verifier = sig_verifier
+
+    @override
+    def verify(self, signature: signing.Signature) -> manifest_module.Manifest:
+        if not isinstance(signature, IntotoSignature):
+            raise TypeError("only IntotoSignature is supported")
+        self._sig_verifier.verify(signature._bundle)
+        return signature.to_manifest()

--- a/src/sign.py
+++ b/src/sign.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Script to sign models."""
+
+import argparse
+import logging
+import pathlib
+
+from model_signing import model
+from model_signing.hashing import file
+from model_signing.hashing import memory
+from model_signing.serialization import serialize_by_file
+from model_signing.signature import fake
+from model_signing.signature import key
+from model_signing.signature import pki
+from model_signing.signature import signing
+from model_signing.signing import in_toto
+from model_signing.signing import in_toto_signature
+
+
+log = logging.getLogger(__name__)
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("Script to sign models")
+    parser.add_argument(
+        "--model_path",
+        help="path to the model to sign",
+        required=True,
+        type=pathlib.Path,
+        dest="model_path",
+    )
+    parser.add_argument(
+        "--sig_out",
+        help="the output file, it defaults ./model.sig",
+        required=False,
+        type=pathlib.Path,
+        default=pathlib.Path("./model.sig"),
+        dest="sig_out",
+    )
+
+    method_cmd = parser.add_subparsers(
+        required=True,
+        dest="method",
+        help="method to sign the model: [pki, private-key, skip]",
+    )
+    # PKI
+    pki = method_cmd.add_parser("pki")
+    pki.add_argument(
+        "--cert_chain",
+        help="paths to pem encoded certificate files or a single file"
+        + "containing a chain",
+        required=False,
+        type=list[str],
+        default=[],
+        nargs="+",
+        dest="cert_chain_path",
+    )
+    pki.add_argument(
+        "--signing_cert",
+        help="the pem encoded signing cert",
+        required=True,
+        type=pathlib.Path,
+        dest="signing_cert_path",
+    )
+    pki.add_argument(
+        "--private_key",
+        help="the path to the private key PEM file",
+        required=True,
+        type=pathlib.Path,
+        dest="key_path",
+    )
+    # private key
+    p_key = method_cmd.add_parser("private-key")
+    p_key.add_argument(
+        "--private_key",
+        help="the path to the private key PEM file",
+        required=True,
+        type=pathlib.Path,
+        dest="key_path",
+    )
+    # skip
+    method_cmd.add_parser("skip")
+
+    return parser.parse_args()
+
+
+def _get_payload_signer(args: argparse.Namespace) -> signing.Signer:
+    if args.method == "private-key":
+        _check_private_key_options(args)
+        return key.ECKeySigner.from_path(private_key_path=args.key_path)
+    elif args.method == "pki":
+        _check_pki_options(args)
+        return pki.PKISigner.from_path(
+            args.key_path, args.signing_cert_path, args.cert_chain_path
+        )
+    elif args.method == "skip":
+        return fake.FakeSigner()
+    else:
+        log.error(f"unsupported signing method {args.method}")
+        log.error('supported methods: ["pki", "private-key", "skip"]')
+        exit(-1)
+
+
+def _check_private_key_options(args: argparse.Namespace):
+    if args.key_path == "":
+        log.error("--private_key must be set to a valid private key PEM file")
+        exit()
+
+
+def _check_pki_options(args: argparse.Namespace):
+    _check_private_key_options(args)
+    if args.signing_cert_path == "":
+        log.error(
+            (
+                "--signing_cert must be set to a valid ",
+                "PEM encoded signing certificate",
+            )
+        )
+        exit()
+    if args.cert_chain_path == "":
+        log.warning("No certificate chain provided")
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    args = _arguments()
+
+    log.info(f"Creating signer for {args.method}")
+    payload_signer = _get_payload_signer(args)
+    log.info(f"Signing model at {args.model_path}")
+
+    def hasher_factory(file_path: pathlib.Path) -> file.FileHasher:
+        return file.SimpleFileHasher(
+            file=file_path, content_hasher=memory.SHA256()
+        )
+
+    serializer = serialize_by_file.ManifestSerializer(
+        file_hasher_factory=hasher_factory
+    )
+
+    intoto_signer = in_toto_signature.IntotoSigner(payload_signer)
+    sig = model.sign(
+        model_path=args.model_path,
+        signer=intoto_signer,
+        payload_generator=in_toto.DigestsIntotoPayload.from_manifest,
+        serializer=serializer,
+        ignore_paths=[args.sig_out],
+    )
+
+    log.info(f'Storing signature at "{args.sig_out}"')
+    sig.write(args.sig_out)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/verify.py
+++ b/src/verify.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This script can be used to verify model signatures."""
+
+import argparse
+import logging
+import pathlib
+
+from model_signing import model
+from model_signing.hashing import file
+from model_signing.hashing import memory
+from model_signing.serialization import serialize_by_file
+from model_signing.signature import fake
+from model_signing.signature import key
+from model_signing.signature import pki
+from model_signing.signature import verifying
+from model_signing.signing import in_toto_signature
+
+
+log = logging.getLogger(__name__)
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("Script to verify models")
+    parser.add_argument(
+        "--sig_path",
+        help="the path to the signature",
+        required=True,
+        type=pathlib.Path,
+        dest="sig_path",
+    )
+    parser.add_argument(
+        "--model_path",
+        help="the path to the model's base folder",
+        type=pathlib.Path,
+        dest="model_path",
+    )
+
+    method_cmd = parser.add_subparsers(
+        required=True,
+        dest="method",
+        help="method to verify the model: [pki, private-key, skip]",
+    )
+    # pki subcommand
+    pki = method_cmd.add_parser("pki")
+    pki.add_argument(
+        "--root_certs",
+        help="paths to PEM encoded certificate files or a single file"
+        + "used as the root of trust",
+        required=False,
+        type=list[str],
+        default=[],
+        dest="root_certs",
+    )
+    # private key subcommand
+    p_key = method_cmd.add_parser("private-key")
+    p_key.add_argument(
+        "--public_key",
+        help="the path to the public key used for verification",
+        required=True,
+        type=pathlib.Path,
+        dest="key",
+    )
+
+    method_cmd.add_parser("skip")
+
+    return parser.parse_args()
+
+
+def _check_private_key_flags(args: argparse.Namespace):
+    if args.key == "":
+        log.error("--public_key must be defined")
+        exit()
+
+
+def _check_pki_flags(args: argparse.Namespace):
+    if not args.root_certs:
+        log.warning("no root of trust is set using system default")
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    args = _arguments()
+
+    verifier: verifying.Verifier
+    log.info(f"Creating verifier for {args.method}")
+    if args.method == "private-key":
+        _check_private_key_flags(args)
+        verifier = key.ECKeyVerifier.from_path(args.key)
+    elif args.method == "pki":
+        _check_pki_flags(args)
+        verifier = pki.PKIVerifier.from_paths(args.root_certs)
+    elif args.method == "skip":
+        verifier = fake.FakeVerifier()
+    else:
+        log.error(f"unsupported verification method {args.method}")
+        log.error('supported methods: ["pki", "private-key", "skip"]')
+        exit(-1)
+
+    log.info(f"Verifying model signature from {args.sig_path}")
+
+    sig = in_toto_signature.IntotoSignature.read(args.sig_path)
+
+    def hasher_factory(file_path: pathlib.Path) -> file.FileHasher:
+        return file.SimpleFileHasher(
+            file=file_path, content_hasher=memory.SHA256()
+        )
+
+    serializer = serialize_by_file.ManifestSerializer(
+        file_hasher_factory=hasher_factory
+    )
+
+    intoto_verifier = in_toto_signature.IntotoVerifier(verifier)
+
+    try:
+        model.verify(
+            sig=sig,
+            verifier=intoto_verifier,
+            model_path=args.model_path,
+            serializer=serializer,
+            ignore_paths=[args.sig_path],
+        )
+    except verifying.VerificationError as err:
+        log.error(f"verification failed: {err}")
+
+    log.info("all checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/signing/in_toto_signature_test.py
+++ b/tests/signing/in_toto_signature_test.py
@@ -66,7 +66,9 @@ class TestIntotoSignature:
         manifest = sig.to_manifest()
         assert shard_manifest == manifest
 
-    def test_sign_and_verify_digest_of_digest_manifest(self, sample_model_folder):
+    def test_sign_and_verify_digest_of_digest_manifest(
+        self, sample_model_folder
+    ):
         signer = in_toto_signature.IntotoSigner(fake.FakeSigner())
         verifier = in_toto_signature.IntotoVerifier(fake.FakeVerifier())
         file_serializer = serialize_by_file.ManifestSerializer(

--- a/tests/signing/in_toto_signature_test.py
+++ b/tests/signing/in_toto_signature_test.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+
+from model_signing.hashing import file
+from model_signing.hashing import memory
+from model_signing.serialization import serialize_by_file
+from model_signing.serialization import serialize_by_file_shard
+from model_signing.signature import fake
+from model_signing.signing import in_toto
+from model_signing.signing import in_toto_signature
+
+
+class TestIntotoSignature:
+    def _shard_hasher_factory(
+        self, path: pathlib.Path, start: int, end: int
+    ) -> file.ShardedFileHasher:
+        return file.ShardedFileHasher(
+            path, memory.SHA256(), start=start, end=end
+        )
+
+    def _hasher_factory(self, path: pathlib.Path) -> file.FileHasher:
+        return file.SimpleFileHasher(path, memory.SHA256())
+
+    def test_sign_and_verify_sharded_manifest(self, sample_model_folder):
+        signer = in_toto_signature.IntotoSigner(fake.FakeSigner())
+        verifier = in_toto_signature.IntotoVerifier(fake.FakeVerifier())
+        shard_serializer = serialize_by_file_shard.ManifestSerializer(
+            self._shard_hasher_factory, allow_symlinks=True
+        )
+        shard_manifest = shard_serializer.serialize(sample_model_folder)
+
+        payload = in_toto.ShardDigestsIntotoPayload.from_manifest(
+            shard_manifest
+        )
+        sig = signer.sign(payload)
+        verifier.verify(sig)
+        manifest = sig.to_manifest()
+        assert shard_manifest == manifest
+
+    def test_sign_and_verify_digest_sharded_manifest(self, sample_model_folder):
+        signer = in_toto_signature.IntotoSigner(fake.FakeSigner())
+        verifier = in_toto_signature.IntotoVerifier(fake.FakeVerifier())
+        shard_serializer = serialize_by_file_shard.ManifestSerializer(
+            self._shard_hasher_factory, allow_symlinks=True
+        )
+        shard_manifest = shard_serializer.serialize(sample_model_folder)
+
+        payload = in_toto.DigestOfShardDigestsIntotoPayload.from_manifest(
+            shard_manifest
+        )
+        sig = signer.sign(payload)
+        verifier.verify(sig)
+        manifest = sig.to_manifest()
+        assert shard_manifest == manifest
+
+    def test_sign_and_verify_digest_of_digest_manifest(self, sample_model_folder):
+        signer = in_toto_signature.IntotoSigner(fake.FakeSigner())
+        verifier = in_toto_signature.IntotoVerifier(fake.FakeVerifier())
+        file_serializer = serialize_by_file.ManifestSerializer(
+            self._hasher_factory, allow_symlinks=True
+        )
+        file_manifest = file_serializer.serialize(sample_model_folder)
+
+        payload = in_toto.DigestOfDigestsIntotoPayload.from_manifest(
+            file_manifest
+        )
+        sig = signer.sign(payload)
+        verifier.verify(sig)
+        manifest = sig.to_manifest()
+        assert file_manifest == manifest
+
+    def test_sign_and_verify_digest_manifest(self, sample_model_folder):
+        signer = in_toto_signature.IntotoSigner(fake.FakeSigner())
+        verifier = in_toto_signature.IntotoVerifier(fake.FakeVerifier())
+        file_serializer = serialize_by_file.ManifestSerializer(
+            self._hasher_factory, allow_symlinks=True
+        )
+        file_manifest = file_serializer.serialize(sample_model_folder)
+
+        payload = in_toto.DigestsIntotoPayload.from_manifest(file_manifest)
+        sig = signer.sign(payload)
+        verifier.verify(sig)
+        manifest = sig.to_manifest()
+        assert file_manifest == manifest


### PR DESCRIPTION
#### Summary

This PR adds scripts to sign and verify `FileLevelManifest`. It combines the existing functionality to create a fully working proof of concept.

Signing workflow:

1. The model folder is hashed using the `SimpleFileHasher` and `FilesSerializer`
2. The resulting `FileLevelManifest` is converted into an in-toto statement. This is only done because sigstore does not support any other payloads in DSSE envelopes.
3. The in-toto statement is signed and wrapped into an DSSE envelope, which in turn is wrapped into a sigstore bundle.
4. The sigstore bundle is converted to json and stored to disk

Verification workflow:

1. The sigstore bundle is loaded from disk
2. The bundle's signature is checked
3. The local model files are serialized into a `FileLevelManifest` using the `SimpleFileHasher` and `FilesSerializer`.
4. The in-toto statement is converted to a `FileLevelManifest`
5. The hashes are compared

#### Release Note

* CLI scripts `sign.py` and `verify.py` to sign and verify models
* Conversion functionality from `FileLevelManifest` to in-toto statement and the other way around
* Adjusted README to reflect the new scripts.
* Removed old `main.py` and `model.py`
