### PR TITLE
Revert "Revert "Chore: Remove hardcoded author/commiter from pin-deps""

### DIFF
--- a/.github/workflows/pin_deps.yml
+++ b/.github/workflows/pin_deps.yml
@@ -113,7 +113,5 @@ jobs:
       with:
         title: "Update frozen python dependencies"
         commit-message: "Bump frozen dependencies"
-        committer: "Mihai Maruseac (automated) <mihaimaruseac@google.com>"
-        author: "Mihai Maruseac (automated) <mihaimaruseac@google.com>"
         signoff: true
         delete-branch: true


### PR DESCRIPTION
Reverts sigstore/model-transparency#239 as it did not work. #246 still needed an empty commit to trigger the other CI runs.