### PR TITLE
combine model serialization logic for files and directories

### DIFF
--- a/model_signing/serialization/serialize_by_file.py
+++ b/model_signing/serialization/serialize_by_file.py
@@ -130,9 +130,9 @@ class FilesSerializer(serialization.Serializer):
         # Python3.12 is the minimum supported version, the glob can be replaced
         # with `pathlib.Path.walk` for a clearer interface, and some speed
         # improvement.
-        def root() -> Iterable[pathlib.Path]:
-            yield model_path
-        for path in itertools.chain(root(), model_path.glob("**/*")):
+        for path in itertools.chain(
+            iter([model_path]), model_path.glob("**/*")
+        ):
             check_file_or_directory(
                 path, allow_symlinks=self._allow_symlinks
             )

--- a/model_signing/serialization/serialize_by_file.py
+++ b/model_signing/serialization/serialize_by_file.py
@@ -17,6 +17,7 @@
 import abc
 import base64
 import concurrent.futures
+import itertools
 import pathlib
 from typing import Callable, Iterable, cast
 from typing_extensions import override
@@ -124,22 +125,19 @@ class FilesSerializer(serialization.Serializer):
             ValueError: The model contains a symbolic link, but the serializer
               was not initialized with `allow_symlinks=True`.
         """
-        check_file_or_directory(model_path, allow_symlinks=self._allow_symlinks)
-
         paths = []
-        if model_path.is_file():
-            paths.append(model_path)
-        else:
-            # TODO: github.com/sigstore/model-transparency/issues/200 - When
-            # Python3.12 is the minimum supported version, this can be replaced
-            # with `pathlib.Path.walk` for a clearer interface, and some speed
-            # improvement.
-            for path in model_path.glob("**/*"):
-                check_file_or_directory(
-                    path, allow_symlinks=self._allow_symlinks
-                )
-                if path.is_file():
-                    paths.append(path)
+        # TODO: github.com/sigstore/model-transparency/issues/200 - When
+        # Python3.12 is the minimum supported version, the glob can be replaced
+        # with `pathlib.Path.walk` for a clearer interface, and some speed
+        # improvement.
+        def root() -> Iterable[pathlib.Path]:
+            yield model_path
+        for path in itertools.chain(root(), model_path.glob("**/*")):
+            check_file_or_directory(
+                path, allow_symlinks=self._allow_symlinks
+            )
+            if path.is_file():
+                paths.append(path)
 
         manifest_items = []
         with concurrent.futures.ThreadPoolExecutor(

--- a/model_signing/serialization/serialize_by_file_shard.py
+++ b/model_signing/serialization/serialize_by_file_shard.py
@@ -17,6 +17,7 @@
 import abc
 import base64
 import concurrent.futures
+import itertools
 import pathlib
 from typing import Callable, Iterable, cast
 from typing_extensions import override
@@ -126,24 +127,19 @@ class ShardedFilesSerializer(serialization.Serializer):
             ValueError: The model contains a symbolic link, but the serializer
               was not initialized with `allow_symlinks=True`.
         """
-        serialize_by_file.check_file_or_directory(
-            model_path, allow_symlinks=self._allow_symlinks
-        )
-
         shards = []
-        if model_path.is_file():
-            shards.extend(self._get_shards(model_path))
-        else:
-            # TODO: github.com/sigstore/model-transparency/issues/200 - When
-            # Python3.12 is the minimum supported version, this can be replaced
-            # with `pathlib.Path.walk` for a clearer interface, and some speed
-            # improvement.
-            for path in model_path.glob("**/*"):
-                serialize_by_file.check_file_or_directory(
-                    path, allow_symlinks=self._allow_symlinks
-                )
-                if path.is_file():
-                    shards.extend(self._get_shards(path))
+        # TODO: github.com/sigstore/model-transparency/issues/200 - When
+        # Python3.12 is the minimum supported version, the glob can be replaced
+        # with `pathlib.Path.walk` for a clearer interface, and some speed
+        # improvement.
+        def root() -> Iterable[pathlib.Path]:
+            yield model_path
+        for path in itertools.chain(root(), model_path.glob("**/*")):
+            serialize_by_file.check_file_or_directory(
+                path, allow_symlinks=self._allow_symlinks
+            )
+            if path.is_file():
+                shards.extend(self._get_shards(path))
 
         manifest_items = []
         with concurrent.futures.ThreadPoolExecutor(

--- a/model_signing/serialization/serialize_by_file_shard.py
+++ b/model_signing/serialization/serialize_by_file_shard.py
@@ -132,9 +132,9 @@ class ShardedFilesSerializer(serialization.Serializer):
         # Python3.12 is the minimum supported version, the glob can be replaced
         # with `pathlib.Path.walk` for a clearer interface, and some speed
         # improvement.
-        def root() -> Iterable[pathlib.Path]:
-            yield model_path
-        for path in itertools.chain(root(), model_path.glob("**/*")):
+        for path in itertools.chain(
+            iter([model_path]), model_path.glob("**/*")
+        ):
             serialize_by_file.check_file_or_directory(
                 path, allow_symlinks=self._allow_symlinks
             )


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Identical logic was being performed whether model_path pointed to a file or a directory due to two pathlib.Path.glob behaviors:

1. The path must be a directory for the generator to yield items
2. The glob does not include the provided directory itself.

By iterating over the provided model_path first, and then continuing to the glob, all of the serialization logic can be done in the loop. This will help future changes which will add more serialization logic in the form of ignore paths (#196).

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

NONE
