### PR TITLE
Add machinery for model signing and verification.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,7 +66,7 @@ jobs:
           pip install -r model_signing/install/requirements_test_Linux.txt
           pip install -r model_signing/install/requirements_dev_Linux.txt
           # TODO: https://github.com/sigstore/model-transparency/issues/231 - Support all repo
-          pytype --keep-going model_signing/{hashing,manifest,serialization,signature}
+          pytype --keep-going model_signing/{hashing,manifest,serialization,signature,signing}
 
   pylint-lint:
     runs-on: ubuntu-latest
@@ -90,4 +90,4 @@ jobs:
           pylint \
             --max-line-length 80 \
             --disable C0114,C0115,C0116,R0801,R0903,R0904,R0913,R0914,R1721,R1737,W0107,W0212,W0223,W0231,W0511,W0621 \
-            model_signing/{hashing,manifest,serialization,signature}
+            model_signing/{hashing,manifest,serialization,signature,signing}

--- a/model_signing/signing/__init__.py
+++ b/model_signing/signing/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/model_signing/signing/empty_signing.py
+++ b/model_signing/signing/empty_signing.py
@@ -45,9 +45,11 @@ class EmptySigningPayload(signing.SigningPayload):
         del manifest  # unused
         return cls()
 
-    def __eq__(self, other: "EmptySigningPayload") -> bool:
-        """Checks that `other` is also an `EmptySigningPayload`."""
-        return isinstance(other, EmptySigningPayload)
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+
+        return True  # all instances are equal
 
 
 class EmptySignature(signing.Signature):
@@ -61,7 +63,7 @@ class EmptySignature(signing.Signature):
     """
 
     @override
-    def write_signature(self, path: pathlib.Path) -> None:
+    def write(self, path: pathlib.Path) -> None:
         """Writes the signature to disk, to the given path.
 
         Since the signature is empty this function actually does nothing, it's
@@ -74,7 +76,7 @@ class EmptySignature(signing.Signature):
 
     @classmethod
     @override
-    def read_signature(cls, path: pathlib.Path) -> Self:
+    def read(cls, path: pathlib.Path) -> Self:
         """Reads the signature from disk.
 
         Since the signature is empty, this does nothing besides just returning
@@ -89,9 +91,11 @@ class EmptySignature(signing.Signature):
         del path  # unused
         return cls()
 
-    def __eq__(self, other: "EmptySignature") -> bool:
-        """Checks that `other` is also an `EmptySignature`."""
-        return isinstance(other, EmptySignature)
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+
+        return True  # all instances are equal
 
 
 class EmptySigner(signing.Signer):

--- a/model_signing/signing/empty_signing.py
+++ b/model_signing/signing/empty_signing.py
@@ -1,0 +1,135 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Empty signing infrastructure.
+
+This is only used to test the signing and verification machinery. It can also be
+used as a default implementation in cases where some of the machinery doesn't
+need to do anything (e.g., in testing or in cases where verification is being
+done from outside the library).
+"""
+
+import pathlib
+from typing import Self
+from typing_extensions import override
+
+from model_signing.manifest import manifest
+from model_signing.signing import signing
+
+
+class EmptySigningPayload(signing.SigningPayload):
+    """An empty signing payload, mostly just for testing."""
+
+    @classmethod
+    @override
+    def from_manifest(cls, manifest: manifest.Manifest) -> Self:
+        """Converts a manifest to the signing payload used for signing.
+
+        Args:
+            manifest: the manifest to convert to signing payload.
+
+        Returns:
+            An instance of `EmptySigningPayload`.
+        """
+        del manifest  # unused
+        return cls()
+
+    def __eq__(self, other: "EmptySigningPayload") -> bool:
+        """Checks that `other` is also an `EmptySigningPayload`."""
+        return isinstance(other, EmptySigningPayload)
+
+
+class EmptySignature(signing.Signature):
+    """Empty signature, mostly for testing.
+
+    Can also be used in cases where the signing result does not need to
+    follow the rest of the signing machinery in this library (e.g., it is
+    verified only by tooling that assume a different flow, or the existing
+    signing machinery already manages writing signatures as a side effect of the
+    signing process).
+    """
+
+    @override
+    def write_signature(self, path: pathlib.Path) -> None:
+        """Writes the signature to disk, to the given path.
+
+        Since the signature is empty this function actually does nothing, it's
+        here just to match the API.
+
+        Args:
+            path: the path to write the signature to. Ignored.
+        """
+        del path  # unused
+
+    @classmethod
+    @override
+    def read_signature(cls, path: pathlib.Path) -> Self:
+        """Reads the signature from disk.
+
+        Since the signature is empty, this does nothing besides just returning
+        an instance of `EmptySignature`.
+
+        Args:
+            path: the path to read the signature from. Ignored.
+
+        Returns:
+            An instance of `EmptySignature`.
+        """
+        del path  # unused
+        return cls()
+
+    def __eq__(self, other: "EmptySignature") -> bool:
+        """Checks that `other` is also an `EmptySignature`."""
+        return isinstance(other, EmptySignature)
+
+
+class EmptySigner(signing.Signer):
+    """A signer that only produces `EmptySignature` objects, for testing."""
+
+    @override
+    def sign(self, payload: signing.SigningPayload) -> EmptySignature:
+        """Signs the provided signing payload.
+
+        Args:
+            payload: the `SigningPayload` instance that should be signed.
+
+        Returns:
+            An `EmptySignature` object.
+        """
+        del payload  # unused
+        return EmptySignature()
+
+
+class EmptyVerifier(signing.Verifier):
+    """Verifier that accepts only `EmptySignature` objects.
+
+    Rather than producing a manifest out of thin air, the verifier also fails to
+    verify the signature, even if it is in the accepted `EmptySignature` format.
+    """
+
+    @override
+    def verify(self, signature: signing.Signature) -> manifest.Manifest:
+        """Verifies the signature.
+
+        Args:
+            signature: the signature to verify.
+
+        Raises:
+            TypeError: If the signature is not an `EmptySignature` instance.
+            ValueError: If the signature is an `EmptySignature` instance. This
+              simulates failing signature verification.
+        """
+        if isinstance(signature, EmptySignature):
+            raise ValueError("Signature verification failed")
+        raise TypeError("Only `EmptySignature` instances are supported")

--- a/model_signing/signing/empty_signing_test.py
+++ b/model_signing/signing/empty_signing_test.py
@@ -53,9 +53,9 @@ class TestEmptySignature:
 
     def test_write_and_read(self):
         signature = empty_signing.EmptySignature()
-        signature.write_signature(test_support.UNUSED_PATH)
+        signature.write(test_support.UNUSED_PATH)
 
-        new_signature = empty_signing.EmptySignature.read_signature(
+        new_signature = empty_signing.EmptySignature.read(
             test_support.UNUSED_PATH
         )
 
@@ -77,12 +77,12 @@ class _FakeSignature(signing.Signature):
     """A test only signature that does nothing."""
 
     @override
-    def write_signature(self, path: pathlib.Path) -> None:
+    def write(self, path: pathlib.Path) -> None:
         del path  # unused, do nothing
 
     @classmethod
     @override
-    def read_signature(cls, path: pathlib.Path) -> Self:
+    def read(cls, path: pathlib.Path) -> Self:
         del path  # unused, do nothing
         return cls()
 

--- a/model_signing/signing/empty_signing_test.py
+++ b/model_signing/signing/empty_signing_test.py
@@ -1,0 +1,110 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+from typing import Self
+import pytest
+from typing_extensions import override
+
+from model_signing import test_support
+from model_signing.hashing import hashing
+from model_signing.manifest import manifest
+from model_signing.signing import empty_signing
+from model_signing.signing import signing
+
+
+class TestEmptySigningPayload:
+
+    def test_build_from_digest_manifest(self):
+        digest = hashing.Digest("test", b"test_digest")
+        manifest_file = manifest.DigestManifest(digest)
+
+        payload = empty_signing.EmptySigningPayload.from_manifest(manifest_file)
+
+        assert payload == empty_signing.EmptySigningPayload()
+
+    def test_build_from_itemized_manifest(self):
+        path1 = pathlib.PurePath("file1")
+        digest1 = hashing.Digest("test", b"abcd")
+        item1 = manifest.FileManifestItem(path=path1, digest=digest1)
+
+        path2 = pathlib.PurePath("file2")
+        digest2 = hashing.Digest("test", b"efgh")
+        item2 = manifest.FileManifestItem(path=path2, digest=digest2)
+
+        manifest_file = manifest.FileLevelManifest([item1, item2])
+        payload = empty_signing.EmptySigningPayload.from_manifest(manifest_file)
+
+        assert payload == empty_signing.EmptySigningPayload()
+
+
+class TestEmptySignature:
+
+    def test_write_and_read(self):
+        signature = empty_signing.EmptySignature()
+        signature.write_signature(test_support.UNUSED_PATH)
+
+        new_signature = empty_signing.EmptySignature.read_signature(
+            test_support.UNUSED_PATH
+        )
+
+        assert new_signature == signature
+
+
+class TestEmptySigner:
+
+    def test_sign_gives_empty_signature(self):
+        payload = empty_signing.EmptySigningPayload()
+        signer = empty_signing.EmptySigner()
+
+        signature = signer.sign(payload)
+
+        assert isinstance(signature, empty_signing.EmptySignature)
+
+
+class _FakeSignature(signing.Signature):
+    """A test only signature that does nothing."""
+
+    @override
+    def write_signature(self, path: pathlib.Path) -> None:
+        del path  # unused, do nothing
+
+    @classmethod
+    @override
+    def read_signature(cls, path: pathlib.Path) -> Self:
+        del path  # unused, do nothing
+        return cls()
+
+
+class TestEmptyVerifier:
+
+    def test_only_empty_signatures_allowed(self):
+        signature = _FakeSignature()
+        verifier = empty_signing.EmptyVerifier()
+
+        with pytest.raises(
+            TypeError,
+            match="Only `EmptySignature` instances are supported",
+        ):
+            verifier.verify(signature)
+
+    def test_verification_always_fails(self):
+        signature = empty_signing.EmptySignature()
+        verifier = empty_signing.EmptyVerifier()
+
+        with pytest.raises(
+            ValueError,
+            match="Signature verification failed",
+        ):
+            verifier.verify(signature)

--- a/model_signing/signing/signing.py
+++ b/model_signing/signing/signing.py
@@ -1,0 +1,157 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Machinery for signing and verification of ML models.
+
+The serialization API produces a manifest representation of the models, and we
+use that to implement integrity checking of models in different computational
+patterns. This means that all manifests need to be kept only in memory.
+
+Hence, for signing, we need a separate class hierarchy to represent the payload.
+This is why we introduce `SigningPayload` abstract class here. Every instance of
+this class is built via a `from_manifest` method (to allow for classes that need
+initialization to be performed only once in their constructor but then convert
+multiple manifests into payloads).
+
+Since we need to support multiple signing methods (e.g., Sigstore, own PKI,
+BCID), we provide a `Signer` abstract class with a single `sign` method that
+takes a signing payload and converts it to a signature in the supported format.
+Since signers may only accept payloads in specific formats, the `sign` method
+can raise a `TypeError` if the provided `SigningPayload` instance is not
+supported (due to typing rules, we cannot just use a subclass type for the
+argument).
+
+Every possible signature will be implemented as a subclass of `Signature` class.
+The API for signatures only allows writing them to disk and parsing them from a
+given path.
+
+Finally, every signature needs to be verified. We pair every `Signer` subclass
+with a `Verifier` which takes a signature, verify the authenticity of the
+payload and then expand that to a `manifest.Manifest` subclass.
+"""
+
+import abc
+import pathlib
+from typing import Self
+
+from model_signing.manifest import manifest
+
+
+class SigningPayload(metaclass=abc.ABCMeta):
+    """Generic payload that we can sign."""
+
+    @classmethod
+    @abc.abstractmethod
+    def from_manifest(cls, manifest: manifest.Manifest) -> Self:
+        """Converts a manifest to the signing payload used for signing.
+
+        Args:
+            manifest: the manifest to convert to signing payload.
+
+        Returns:
+            An instance of `SigningPayload` or subclass of it.
+        """
+        pass
+
+
+class Signature(metaclass=abc.ABCMeta):
+    """Generic signature support."""
+
+    @abc.abstractmethod
+    def write_signature(self, path: pathlib.Path) -> None:
+        """Writes the signature to disk, to the given path.
+
+        Args:
+            path: the path to write the signature to.
+        """
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def read_signature(cls, path: pathlib.Path) -> Self:
+        """Reads the signature from disk.
+
+        Does not perform any signature verification, except what is needed to
+        parse the signature file.
+
+        Args:
+            path: the path to read the signature from.
+
+        Returns:
+            An instance of the class which can be passed to a `Verifier` for
+            signature and integrity verification.
+
+        Raises:
+            ValueError: If the provided path is not deserializable to the format
+              expected by the `Signature` (sub)class.
+        """
+        pass
+
+
+class Signer(metaclass=abc.ABCMeta):
+    """Generic signer for `SigningPayload` objects.
+
+    Every signer is allowed to only support some signing payload formats. Every
+    signer produces a signature in its own format. No signer is required to
+    support all subclasses of `SigningPayload` or `Signature`.
+
+    Each signer may implement its own mechanism for managing the key material.
+    """
+
+    @abc.abstractmethod
+    def sign(self, payload: SigningPayload) -> Signature:
+        """Signs the provided signing payload.
+
+        Args:
+            payload: the `SigningPayload` instance that should be signed.
+
+        Returns:
+            A valid signature.
+
+        Raises:
+            TypeError: If the `payload` type is not one of the subclasses of
+              `SigningPayload` that are supported.
+        """
+        pass
+
+
+class Verifier(metaclass=abc.ABCMeta):
+    """Generic signature verifier.
+
+    Every subclass of `Verifier` is paired with a subclass of `Signer`. This is
+    to ensure that they support the same signing payload and signature formats
+    as well as have similar key materialsEvery subclass of `Verifier` is paired
+    with a subclass of `Signer`. This is to ensure that they support the same
+    signing payload and signature formats as well as have similar key materials.
+
+    If the signature is valid, the payload is expanded to a `Manifest` instance
+    which can then be used to check the model integrity.
+    """
+
+    @abc.abstractmethod
+    def verify(self, signature: Signature) -> manifest.Manifest:
+        """Verifies the signature.
+
+        Args:
+            signature: the signature to verify.
+
+        Returns:
+            A `manifest.Manifest` instance that represents the model.
+
+        Raises:
+            ValueError: If the signature cannot be verified.
+            TypeError: If the signature is not one of the `Signature` subclasses
+              accepted by the verifier.
+        """
+        pass

--- a/model_signing/signing/signing.py
+++ b/model_signing/signing/signing.py
@@ -69,7 +69,7 @@ class Signature(metaclass=abc.ABCMeta):
     """Generic signature support."""
 
     @abc.abstractmethod
-    def write_signature(self, path: pathlib.Path) -> None:
+    def write(self, path: pathlib.Path) -> None:
         """Writes the signature to disk, to the given path.
 
         Args:
@@ -79,7 +79,7 @@ class Signature(metaclass=abc.ABCMeta):
 
     @classmethod
     @abc.abstractmethod
-    def read_signature(cls, path: pathlib.Path) -> Self:
+    def read(cls, path: pathlib.Path) -> Self:
         """Reads the signature from disk.
 
         Does not perform any signature verification, except what is needed to
@@ -131,9 +131,7 @@ class Verifier(metaclass=abc.ABCMeta):
 
     Every subclass of `Verifier` is paired with a subclass of `Signer`. This is
     to ensure that they support the same signing payload and signature formats
-    as well as have similar key materialsEvery subclass of `Verifier` is paired
-    with a subclass of `Signer`. This is to ensure that they support the same
-    signing payload and signature formats as well as have similar key materials.
+    as well as have similar key materials.
 
     If the signature is valid, the payload is expanded to a `Manifest` instance
     which can then be used to check the model integrity.
@@ -150,7 +148,7 @@ class Verifier(metaclass=abc.ABCMeta):
             A `manifest.Manifest` instance that represents the model.
 
         Raises:
-            ValueError: If the signature cannot be verified.
+            ValueError: If the signature verification fails.
             TypeError: If the signature is not one of the `Signature` subclasses
               accepted by the verifier.
         """


### PR DESCRIPTION
#### Summary
Added a set of `Empty*` classes just to show how these would be used in OSS. I'll send another PR for the actual in-toto classes, but this one mirrors the internal changelist where the API gets introduced.

For the 2 `serialize_*_test.py` files: just ordered the imports to match the internal style.

#### Release Note
NONE

#### Documentation
NONE