### PR TITLE
Add file-only and folder-only test model lists

### DIFF
--- a/model_signing/test_support.py
+++ b/model_signing/test_support.py
@@ -43,6 +43,24 @@ all_test_models = [
 ]
 
 
+# All directory models to use in testing, where only non empty directory models
+# are supported. See also `all_test_models` comments.
+all_non_empty_directory_test_models = [
+    "sample_model_folder",
+    "deep_model_folder",
+    "model_folder_with_empty_file",
+    "symlink_model_folder",
+]
+
+
+# All files models to use in testing, where only file models are supported.
+all_file_test_models = [
+    "sample_model_file",
+    "empty_model_file",
+    "model_folder_with_empty_file",
+]
+
+
 def get_first_directory(path: pathlib.Path) -> pathlib.Path:
     """Returns the first directory that is a children of path.
 


### PR DESCRIPTION
#### Summary
Adding `all_non_empty_directory_test_models` and `all_file_test_models` lists that cover the corresponding fixtures to be able to use just these subset of test models in testing, without having to list them one by one.

#### Release Note
NONE
#### Documentation
NONE