### PR TITLE
Create in-toto signing payload for single digests.

### DIFF
--- a/model_signing/signing/in_toto.py
+++ b/model_signing/signing/in_toto.py
@@ -1,0 +1,125 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Signing payloads for models as in-toto statements.
+
+To generate the signing payload we convert model manifests to in-toto formats,
+as described by https://github.com/in-toto/attestation/tree/main/spec/v1. The
+envelope format is DSSE, see https://github.com/secure-systems-lab/dsse.
+"""
+
+from typing import Final, Self
+
+from in_toto_attestation.v1 import statement
+from typing_extensions import override
+
+from model_signing.manifest import manifest as manifest_module
+from model_signing.signing import signing
+
+
+class IntotoPayload(signing.SigningPayload):
+    """A generic payload in in-toto format.
+
+    This class is abstract for now as we will support multiple payload formats
+    below.
+
+    Each subclass defines a constant for the predicate type class attribute
+    defined below.
+    """
+
+    predicate_type: Final[str]
+
+
+class SingleDigestIntotoPayload(IntotoPayload):
+    """In-toto payload where the model is serialized to just one digest.
+
+    In this case, we encode the model as the only subject of the statement. We
+    don't set the name field, and use the digest as the one resulting from the
+    model serialization.
+
+    However, since we use custom hashing algorithms, but these are not supported
+    by existing tools, we claim that the digest algorithm is sha-256 and include
+    the real digest in the predicate.
+
+    Example:
+    ```json
+    {
+      "_type": "https://in-toto.io/Statement/v1",
+      "subject": [
+        {
+          "digest": {
+            "sha256": "3aab065c...."
+          }
+        }
+      ],
+      "predicateType": "https://model_signing/Digest/v0.1",
+      "predicate": {
+        "actual_hash_algorithm": "file-sha256"
+      }
+    }
+    ```
+
+    If the predicate is missing (or does not set "actual_hash_algorithm"), it
+    should be assumed that the digest is actually computed via the algorithm
+    present in the resource descriptor (i.e., sha256).
+
+    See also https://github.com/sigstore/sigstore-python/issues/1018.
+    """
+
+    predicate_type: Final[str] = "https://model_signing/Digest/v0.1"
+
+    def __init__(self, *, digest_hex: str, digest_algorithm: str):
+        """Builds an instance of this in-toto payload.
+
+        Don't call this directly in production. Use `from_manifest()` instead.
+
+        Args:
+            digest_hex: the hexadecimal, human readable, digest of the subject.
+            digest_algorithm: the algorithm used to compute the digest.
+        """
+        digest = {"sha256": digest_hex}
+        descriptor = statement.ResourceDescriptor(digest=digest).pb
+
+        self.statement = statement.Statement(
+            subjects=[descriptor],
+            predicate_type=self.predicate_type,
+            predicate={"actual_hash_algorithm": digest_algorithm},
+        )
+
+    @classmethod
+    @override
+    def from_manifest(cls, manifest: manifest_module.Manifest) -> Self:
+        """Converts a manifest to the signing payload used for signing.
+
+        The manifest must be a `DigestManifest` instance.
+
+        Args:
+            manifest: the manifest to convert to signing payload.
+
+        Returns:
+            An instance of `SingleDigestIntotoPayload`.
+
+        Raises:
+            TypeError: If the manifest is not `DigestManifest`.
+        """
+        if not isinstance(manifest, manifest_module.DigestManifest):
+            raise TypeError("Only DigestManifest is supported")
+
+        # guaranteed to have exactly one item
+        subject = list(manifest.resource_descriptors())[0]
+        digest = subject.digest
+        return cls(
+            digest_hex=digest.digest_hex,
+            digest_algorithm=digest.algorithm,
+        )

--- a/model_signing/signing/in_toto_test.py
+++ b/model_signing/signing/in_toto_test.py
@@ -1,0 +1,87 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for in-toto signing payloads.
+
+NOTE: This test uses a goldens setup to compare expected results with data from
+files. If the golden tests are failing, regenerate the golden files with
+
+  pytest model_signing/ --update_goldens
+"""
+
+from google.protobuf import json_format
+from in_toto_attestation.v1 import statement_pb2
+import pytest
+
+from model_signing import test_support
+from model_signing.hashing import file
+from model_signing.hashing import hashing
+from model_signing.hashing import memory
+from model_signing.manifest import manifest as manifest_module
+from model_signing.serialization import serialize_by_file
+from model_signing.signing import in_toto
+
+
+class TestSingleDigestIntotoPayload:
+
+    @pytest.mark.parametrize("model_fixture_name", test_support.all_test_models)
+    def test_known_models(self, request, model_fixture_name):
+        # Set up variables (arrange)
+        testdata_path = request.path.parent / "testdata"
+        test_path = testdata_path / "in_toto"
+        test_class_path = test_path / "TestSingleDigestIntotoPayload"
+        golden_path = test_class_path / model_fixture_name
+        should_update = request.config.getoption("update_goldens")
+        model = request.getfixturevalue(model_fixture_name)
+
+        # Compute payload (act)
+        file_hasher = file.SimpleFileHasher(
+            test_support.UNUSED_PATH, memory.SHA256()
+        )
+        serializer = serialize_by_file.DigestSerializer(
+            file_hasher, memory.SHA256, allow_symlinks=True
+        )
+        manifest = serializer.serialize(model)
+        payload = in_toto.SingleDigestIntotoPayload.from_manifest(manifest)
+
+        # Compare with golden, or write to golden (approximately "assert")
+        if should_update:
+            with open(golden_path, "w", encoding="utf-8") as f:
+                f.write(f"{json_format.MessageToJson(payload.statement.pb)}\n")
+        else:
+            with open(golden_path, "r", encoding="utf-8") as f:
+                json_contents = f.read()
+                expected_proto = json_format.Parse(
+                    json_contents, statement_pb2.Statement()
+                )
+
+            assert payload.statement.pb == expected_proto
+
+    def test_produces_valid_statements(self):
+        digest = hashing.Digest("test", b"test_digest")
+        manifest = manifest_module.DigestManifest(digest)
+
+        payload = in_toto.SingleDigestIntotoPayload.from_manifest(manifest)
+
+        payload.statement.validate()
+
+    def test_only_runs_on_expected_manifest_types(self, sample_model_folder):
+        serializer = serialize_by_file.ManifestSerializer(
+            lambda f: file.SimpleFileHasher(f, memory.SHA256()),
+            allow_symlinks=True,
+        )
+        manifest = serializer.serialize(sample_model_folder)
+
+        with pytest.raises(TypeError, match="Only DigestManifest is supported"):
+            in_toto.SingleDigestIntotoPayload.from_manifest(manifest)

--- a/model_signing/signing/testdata/in_toto/TestSingleDigestIntotoPayload/deep_model_folder
+++ b/model_signing/signing/testdata/in_toto/TestSingleDigestIntotoPayload/deep_model_folder
@@ -1,0 +1,14 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "36eed9389ebbbe15ac15d33c81dabb60ccb7c945ff641d78f59db9aa9dc47ac9"
+      }
+    }
+  ],
+  "predicateType": "https://model_signing/Digest/v0.1",
+  "predicate": {
+    "actual_hash_algorithm": "sha256"
+  }
+}

--- a/model_signing/signing/testdata/in_toto/TestSingleDigestIntotoPayload/empty_model_file
+++ b/model_signing/signing/testdata/in_toto/TestSingleDigestIntotoPayload/empty_model_file
@@ -1,0 +1,14 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    }
+  ],
+  "predicateType": "https://model_signing/Digest/v0.1",
+  "predicate": {
+    "actual_hash_algorithm": "file-sha256"
+  }
+}

--- a/model_signing/signing/testdata/in_toto/TestSingleDigestIntotoPayload/empty_model_folder
+++ b/model_signing/signing/testdata/in_toto/TestSingleDigestIntotoPayload/empty_model_folder
@@ -1,0 +1,14 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    }
+  ],
+  "predicateType": "https://model_signing/Digest/v0.1",
+  "predicate": {
+    "actual_hash_algorithm": "sha256"
+  }
+}

--- a/model_signing/signing/testdata/in_toto/TestSingleDigestIntotoPayload/model_folder_with_empty_file
+++ b/model_signing/signing/testdata/in_toto/TestSingleDigestIntotoPayload/model_folder_with_empty_file
@@ -1,0 +1,14 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "68efd863f20e083173846a5e98ad11387a1979efe20ded426a7930bab8358a9c"
+      }
+    }
+  ],
+  "predicateType": "https://model_signing/Digest/v0.1",
+  "predicate": {
+    "actual_hash_algorithm": "sha256"
+  }
+}

--- a/model_signing/signing/testdata/in_toto/TestSingleDigestIntotoPayload/sample_model_file
+++ b/model_signing/signing/testdata/in_toto/TestSingleDigestIntotoPayload/sample_model_file
@@ -1,0 +1,14 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "3aab065c7181a173b5dd9e9d32a9f79923440b413be1e1ffcdba26a7365f719b"
+      }
+    }
+  ],
+  "predicateType": "https://model_signing/Digest/v0.1",
+  "predicate": {
+    "actual_hash_algorithm": "file-sha256"
+  }
+}

--- a/model_signing/signing/testdata/in_toto/TestSingleDigestIntotoPayload/sample_model_folder
+++ b/model_signing/signing/testdata/in_toto/TestSingleDigestIntotoPayload/sample_model_folder
@@ -1,0 +1,14 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "310af4fc4c52bf63cd1687c67076ed3e56bc5480a1b151539e6c550506ae0301"
+      }
+    }
+  ],
+  "predicateType": "https://model_signing/Digest/v0.1",
+  "predicate": {
+    "actual_hash_algorithm": "sha256"
+  }
+}

--- a/model_signing/signing/testdata/in_toto/TestSingleDigestIntotoPayload/symlink_model_folder
+++ b/model_signing/signing/testdata/in_toto/TestSingleDigestIntotoPayload/symlink_model_folder
@@ -1,0 +1,14 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "8372365be7578241d18db47ec83b735bb450a10a1b4298d9b7b0d8bf543b7271"
+      }
+    }
+  ],
+  "predicateType": "https://model_signing/Digest/v0.1",
+  "predicate": {
+    "actual_hash_algorithm": "sha256"
+  }
+}


### PR DESCRIPTION
#### Summary
This converts `DigestManifest`s objects to an in-toto format where the model is identified by its complete digest (as result of the serialization).

For Sigstore signing, this payload can be signed via `sign_intoto`, producing a Sigstore `Bundle` as the signature.

CC @susperius for converting manifest to in-toto. This should cover #111, #224, and #248 (first part of the machinery). CC @laurentsimon to make sure I did not mishandle in-toto.

**Note**: Looking at the goldens, I see that some of the hashes are not properly converted to the one we use in serialization (should always be `file-sha256` in the current testing scenario). I was planning to debug that before pushing this work, but given #260 I'll send it now to reduce work duplication and will debug the issue next week.

**Note**: Disabling C0103 and E1101 in the pylint configuration. The first one is about the name of the class constant, it wants it to be all uppercase, but that goes against established style for class/instance variables. Worse, the second one fails to detect that protobuf generated code has certain attributes/names. This is because [pylint does not use .pyi files, which is what protobuf generates](https://github.com/pylint-dev/pylint/issues/6281), but we can disable it given this missing attribute would be detected by pytype, which works correctly. Maybe when switching linter we'd get rid of this issue.

#### Release Note
NONE
#### Documentation
NONE