### PR TITLE
add ability to ignore paths during model serialization

### DIFF
--- a/model_signing/serialization/serialization.py
+++ b/model_signing/serialization/serialization.py
@@ -32,7 +32,18 @@ class Serializer(metaclass=abc.ABCMeta):
     def serialize(
         self,
         model_path: pathlib.Path,
+        *,
         ignore_paths: Iterable[pathlib.Path] = frozenset(),
     ) -> manifest.Manifest:
-        """Serializes the model given by the `model_path` argument."""
+        """Serializes the model given by the `model_path` argument.
+
+        Args:
+            model_path: The path to the model.
+            ignore_paths: The paths to ignore during serialization. If a
+              provided path is a directory, all children of the directory are
+              ignored.
+
+        Returns:
+            The model's serialized `manifest.Manifest`
+        """
         pass

--- a/model_signing/serialization/serialization.py
+++ b/model_signing/serialization/serialization.py
@@ -21,6 +21,8 @@ directory, but more serializers are coming soon.
 import abc
 import pathlib
 
+from collections.abc import Iterable
+
 from model_signing.manifest import manifest
 
 
@@ -28,6 +30,10 @@ class Serializer(metaclass=abc.ABCMeta):
     """Generic ML model format serializer."""
 
     @abc.abstractmethod
-    def serialize(self, model_path: pathlib.Path) -> manifest.Manifest:
+    def serialize(
+        self,
+        model_path: pathlib.Path,
+        ignore_paths: Iterable[pathlib.Path] = frozenset(),
+    ) -> manifest.Manifest:
         """Serializes the model given by the `model_path` argument."""
         pass

--- a/model_signing/serialization/serialization.py
+++ b/model_signing/serialization/serialization.py
@@ -19,9 +19,8 @@ directory, but more serializers are coming soon.
 """
 
 import abc
-import pathlib
-
 from collections.abc import Iterable
+import pathlib
 
 from model_signing.manifest import manifest
 

--- a/model_signing/serialization/serialize_by_file.py
+++ b/model_signing/serialization/serialize_by_file.py
@@ -16,11 +16,12 @@
 
 import abc
 import base64
+from collections.abc import Callable, Iterable
 import concurrent.futures
 import itertools
 import pathlib
-from collections.abc import Callable, Iterable
 from typing import cast
+
 from typing_extensions import override
 
 from model_signing.hashing import file

--- a/model_signing/serialization/serialize_by_file.py
+++ b/model_signing/serialization/serialize_by_file.py
@@ -216,8 +216,10 @@ class ManifestSerializer(FilesSerializer):
             ValueError: The model contains a symbolic link, but the serializer
               was not initialized with `allow_symlinks=True`.
         """
-        return cast(manifest.FileLevelManifest,
-                    super().serialize(model_path, ignore_paths))
+        return cast(
+            manifest.FileLevelManifest,
+            super().serialize(model_path, ignore_paths),
+        )
 
     @override
     def _build_manifest(
@@ -358,8 +360,9 @@ class DigestSerializer(FilesSerializer):
             ValueError: The model contains a symbolic link, but the serializer
               was not initialized with `allow_symlinks=True`.
         """
-        return cast(manifest.DigestManifest,
-                    super().serialize(model_path, ignore_paths))
+        return cast(
+            manifest.DigestManifest, super().serialize(model_path, ignore_paths)
+        )
 
     @override
     def _build_manifest(

--- a/model_signing/serialization/serialize_by_file.py
+++ b/model_signing/serialization/serialize_by_file.py
@@ -130,9 +130,7 @@ class FilesSerializer(serialization.Serializer):
         # Python3.12 is the minimum supported version, the glob can be replaced
         # with `pathlib.Path.walk` for a clearer interface, and some speed
         # improvement.
-        for path in itertools.chain(
-            iter([model_path]), model_path.glob("**/*")
-        ):
+        for path in itertools.chain((model_path,), model_path.glob("**/*")):
             check_file_or_directory(
                 path, allow_symlinks=self._allow_symlinks
             )

--- a/model_signing/serialization/serialize_by_file.py
+++ b/model_signing/serialization/serialize_by_file.py
@@ -136,9 +136,19 @@ class FilesSerializer(serialization.Serializer):
     @override
     def serialize(self,
         model_path: pathlib.Path,
+        *,
         ignore_paths: Iterable[pathlib.Path] = frozenset(),
     ) -> manifest.Manifest:
         """Serializes the model given by the `model_path` argument.
+
+        Args:
+            model_path: The path to the model.
+            ignore_paths: The paths to ignore during serialization. If a
+              provided path is a directory, all children of the directory are
+              ignored.
+
+        Returns:
+            The model's serialized `manifest.Manifest`
 
         Raises:
             ValueError: The model contains a symbolic link, but the serializer
@@ -204,6 +214,7 @@ class ManifestSerializer(FilesSerializer):
     @override
     def serialize(self,
         model_path: pathlib.Path,
+        *,
         ignore_paths: Iterable[pathlib.Path] = frozenset(),
     ) -> manifest.FileLevelManifest:
         """Serializes the model given by the `model_path` argument.
@@ -212,13 +223,22 @@ class ManifestSerializer(FilesSerializer):
         more restrictive. This is to signal that the only manifests that can be
         returned are `manifest.FileLevelManifest` instances.
 
+        Args:
+            model_path: The path to the model.
+            ignore_paths: The paths to ignore during serialization. If a
+              provided path is a directory, all children of the directory are
+              ignored.
+
+        Returns:
+            The model's serialized `manifest.FileLevelManifest`
+
         Raises:
             ValueError: The model contains a symbolic link, but the serializer
               was not initialized with `allow_symlinks=True`.
         """
         return cast(
             manifest.FileLevelManifest,
-            super().serialize(model_path, ignore_paths),
+            super().serialize(model_path, ignore_paths=ignore_paths),
         )
 
     @override
@@ -348,6 +368,7 @@ class DigestSerializer(FilesSerializer):
     @override
     def serialize(self,
         model_path: pathlib.Path,
+        *,
         ignore_paths: Iterable[pathlib.Path] = frozenset(),
     ) -> manifest.DigestManifest:
         """Serializes the model given by the `model_path` argument.
@@ -356,12 +377,22 @@ class DigestSerializer(FilesSerializer):
         more restrictive. This is to signal that the only manifests that can be
         returned are `manifest.DigestManifest` instances.
 
+        Args:
+            model_path: The path to the model.
+            ignore_paths: The paths to ignore during serialization. If a
+              provided path is a directory, all children of the directory are
+              ignored.
+
+        Returns:
+            The model's serialized `manifest.DigestManifest`
+
         Raises:
             ValueError: The model contains a symbolic link, but the serializer
               was not initialized with `allow_symlinks=True`.
         """
         return cast(
-            manifest.DigestManifest, super().serialize(model_path, ignore_paths)
+            manifest.DigestManifest,
+            super().serialize(model_path, ignore_paths=ignore_paths),
         )
 
     @override

--- a/model_signing/serialization/serialize_by_file_shard.py
+++ b/model_signing/serialization/serialize_by_file_shard.py
@@ -16,11 +16,12 @@
 
 import abc
 import base64
+from collections.abc import Callable, Iterable
 import concurrent.futures
 import itertools
 import pathlib
-from collections.abc import Callable, Iterable
 from typing import cast
+
 from typing_extensions import override
 
 from model_signing.hashing import file

--- a/model_signing/serialization/serialize_by_file_shard.py
+++ b/model_signing/serialization/serialize_by_file_shard.py
@@ -132,9 +132,7 @@ class ShardedFilesSerializer(serialization.Serializer):
         # Python3.12 is the minimum supported version, the glob can be replaced
         # with `pathlib.Path.walk` for a clearer interface, and some speed
         # improvement.
-        for path in itertools.chain(
-            iter([model_path]), model_path.glob("**/*")
-        ):
+        for path in itertools.chain((model_path,), model_path.glob("**/*")):
             serialize_by_file.check_file_or_directory(
                 path, allow_symlinks=self._allow_symlinks
             )

--- a/model_signing/serialization/serialize_by_file_shard.py
+++ b/model_signing/serialization/serialize_by_file_shard.py
@@ -124,9 +124,19 @@ class ShardedFilesSerializer(serialization.Serializer):
     @override
     def serialize(self,
         model_path: pathlib.Path,
+        *,
         ignore_paths: Iterable[pathlib.Path] = frozenset(),
     ) -> manifest.Manifest:
         """Serializes the model given by the `model_path` argument.
+
+        Args:
+            model_path: The path to the model.
+            ignore_paths: The paths to ignore during serialization. If a
+              provided path is a directory, all children of the directory are
+              ignored.
+
+        Returns:
+            The model's serialized `manifest.Manifest`
 
         Raises:
             ValueError: The model contains a symbolic link, but the serializer
@@ -217,13 +227,23 @@ class ManifestSerializer(ShardedFilesSerializer):
     def serialize(
         self,
         model_path: pathlib.Path,
+        *,
         ignore_paths: Iterable[pathlib.Path] = frozenset(),
     ) -> manifest.ShardLevelManifest:
         """Serializes the model given by the `model_path` argument.
 
         The only reason for the override is to change the return type, to be
         more restrictive. This is to signal that the only manifests that can be
-        returned are `manifest.FileLevelManifest` instances.
+        returned are `manifest.ShardLevelManifest` instances.
+
+        Args:
+            model_path: The path to the model.
+            ignore_paths: The paths to ignore during serialization. If a
+              provided path is a directory, all children of the directory are
+              ignored.
+
+        Returns:
+            The model's serialized `manifest.ShardLevelManifest`
 
         Raises:
             ValueError: The model contains a symbolic link, but the serializer
@@ -231,7 +251,7 @@ class ManifestSerializer(ShardedFilesSerializer):
         """
         return cast(
             manifest.ShardLevelManifest,
-            super().serialize(model_path, ignore_paths),
+            super().serialize(model_path, ignore_paths=ignore_paths),
         )
 
     @override
@@ -278,20 +298,31 @@ class DigestSerializer(ShardedFilesSerializer):
     @override
     def serialize(self,
         model_path: pathlib.Path,
+        *,
         ignore_paths: Iterable[pathlib.Path] = frozenset(),
     ) -> manifest.DigestManifest:
         """Serializes the model given by the `model_path` argument.
 
         The only reason for the override is to change the return type, to be
         more restrictive. This is to signal that the only manifests that can be
-        returned are `manifest.FileLevelManifest` instances.
+        returned are `manifest.DigestManifest` instances.
+
+        Args:
+            model_path: The path to the model.
+            ignore_paths: The paths to ignore during serialization. If a
+              provided path is a directory, all children of the directory are
+              ignored.
+
+        Returns:
+            The model's serialized `manifest.DigestManifest`
 
         Raises:
             ValueError: The model contains a symbolic link, but the serializer
               was not initialized with `allow_symlinks=True`.
         """
         return cast(
-            manifest.DigestManifest, super().serialize(model_path, ignore_paths)
+            manifest.DigestManifest,
+            super().serialize(model_path, ignore_paths=ignore_paths),
         )
 
     @override

--- a/model_signing/serialization/serialize_by_file_shard.py
+++ b/model_signing/serialization/serialize_by_file_shard.py
@@ -229,8 +229,10 @@ class ManifestSerializer(ShardedFilesSerializer):
             ValueError: The model contains a symbolic link, but the serializer
               was not initialized with `allow_symlinks=True`.
         """
-        return cast(manifest.ShardLevelManifest,
-                    super().serialize(model_path, ignore_paths))
+        return cast(
+            manifest.ShardLevelManifest,
+            super().serialize(model_path, ignore_paths),
+        )
 
     @override
     def _build_manifest(
@@ -288,8 +290,9 @@ class DigestSerializer(ShardedFilesSerializer):
             ValueError: The model contains a symbolic link, but the serializer
               was not initialized with `allow_symlinks=True`.
         """
-        return cast(manifest.DigestManifest,
-                    super().serialize(model_path, ignore_paths))
+        return cast(
+            manifest.DigestManifest, super().serialize(model_path, ignore_paths)
+        )
 
     @override
     def _build_manifest(

--- a/model_signing/serialization/serialize_by_file_shard_test.py
+++ b/model_signing/serialization/serialize_by_file_shard_test.py
@@ -21,6 +21,7 @@ models. If the golden tests are failing, regenerate the golden files with
 """
 
 import pathlib
+
 import pytest
 
 from model_signing import test_support

--- a/model_signing/serialization/serialize_by_file_test.py
+++ b/model_signing/serialization/serialize_by_file_test.py
@@ -22,6 +22,7 @@ models. If the golden tests are failing, regenerate the golden files with
 
 import os
 import pathlib
+
 import pytest
 
 from model_signing import test_support

--- a/model_signing/test_support.py
+++ b/model_signing/test_support.py
@@ -14,6 +14,7 @@
 
 """Helpers and constants used in fixtures and tests. Not in the public API."""
 
+import itertools
 import pathlib
 
 from model_signing.manifest import manifest
@@ -105,10 +106,8 @@ def count_files(path: pathlib.Path) -> int:
 
     If path is a file, the count returned is 1.
     """
-    if path.is_file():
-        return 1
     count = 0
-    for child_path in path.glob("**/*"):
+    for child_path in itertools.chain((path,), path.glob("**/*")):
         if child_path.is_file():
             count += 1
     return count

--- a/model_signing/test_support.py
+++ b/model_signing/test_support.py
@@ -100,3 +100,16 @@ def extract_items_from_manifest(
         str(path): digest.digest_hex
         for path, digest in manifest._item_to_digest.items()
     }
+
+def count_files(path: pathlib.Path) -> int:
+    """Counts the number of files that are children of path.
+
+    If path is a file, the count returned is 1.
+    """
+    if path.is_file():
+        return 1
+    count = 0
+    for child_path in path.glob("**/*"):
+        if child_path.is_file():
+            count += 1
+    return count

--- a/model_signing/test_support.py
+++ b/model_signing/test_support.py
@@ -18,7 +18,6 @@ import pathlib
 
 from model_signing.manifest import manifest
 
-
 # Model contents
 KNOWN_MODEL_TEXT: bytes = b"This is a simple model"
 ANOTHER_MODEL_TEXT: bytes = b"This is another simple model"


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Adds the ability to pass in one or more ignore paths to exclude files and/or directories during model serialization.

Closes #196 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

NONE