### PR TITLE
mark serialization optional arguments as keyword-only

### DIFF
--- a/model_signing/serialization/serialize_by_file.py
+++ b/model_signing/serialization/serialize_by_file.py
@@ -32,6 +32,7 @@ from model_signing.serialization import serialization
 
 def check_file_or_directory(
     path: pathlib.Path,
+    *,
     allow_symlinks: bool = False,
 ) -> None:
     """Checks that the given path is either a file or a directory.
@@ -115,6 +116,7 @@ class FilesSerializer(serialization.Serializer):
     def __init__(
         self,
         file_hasher_factory: Callable[[pathlib.Path], file.FileHasher],
+        *,
         max_workers: int | None = None,
         allow_symlinks: bool = False,
     ):
@@ -344,6 +346,7 @@ class DigestSerializer(FilesSerializer):
         self,
         file_hasher: file.SimpleFileHasher,
         merge_hasher_factory: Callable[[], hashing.StreamingHashEngine],
+        *,
         allow_symlinks: bool = False,
     ):
         """Initializes an instance to serialize a model with this serializer.

--- a/model_signing/serialization/serialize_by_file_shard.py
+++ b/model_signing/serialization/serialize_by_file_shard.py
@@ -95,6 +95,7 @@ class ShardedFilesSerializer(serialization.Serializer):
         sharded_hasher_factory: Callable[
             [pathlib.Path, int, int], file.ShardedFileHasher
         ],
+        *,
         max_workers: int | None = None,
         allow_symlinks: bool = False,
     ):
@@ -273,6 +274,7 @@ class DigestSerializer(ShardedFilesSerializer):
             [pathlib.Path, int, int], file.ShardedFileHasher
         ],
         merge_hasher: hashing.StreamingHashEngine,
+        *,
         max_workers: int | None = None,
         allow_symlinks: bool = False,
     ):
@@ -292,7 +294,11 @@ class DigestSerializer(ShardedFilesSerializer):
               symlink is present but the flag is `False` (default) the
               serialization would raise an error.
         """
-        super().__init__(file_hasher_factory, max_workers, allow_symlinks)
+        super().__init__(
+            file_hasher_factory,
+            max_workers=max_workers,
+            allow_symlinks=allow_symlinks,
+        )
         self._merge_hasher = merge_hasher
 
     @override


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Follow-up of https://github.com/sigstore/model-transparency/pull/269#discussion_r1697364057, marks `allow_symlinks` and `max_workers` as keyword-only arguments for better future-proofing.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

NONE