### PR TITLE
Replace pylint with ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,7 +68,7 @@ jobs:
           # TODO: https://github.com/sigstore/model-transparency/issues/231 - Support all repo
           pytype --keep-going model_signing/{hashing,manifest,serialization,signature,signing}
 
-  pylint-lint:
+  ruff-lint:
     runs-on: ubuntu-latest
     name: Python lint
     steps:
@@ -78,7 +78,7 @@ jobs:
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           python-version: "3.11"
-      - name: run pylint
+      - name: run ruff
         run: |
           python -m venv venv
           .github/workflows/scripts/venv_activate.sh
@@ -86,8 +86,4 @@ jobs:
           pip install -r model_signing/install/requirements_test_Linux.txt
           pip install -r model_signing/install/requirements_dev_Linux.txt
           # TODO: https://github.com/sigstore/model-transparency/issues/231 - Support all repo
-          # We should actually migrate to ruff, but that's configured via pyproject.toml which we use when we release the wheel
-          pylint \
-            --max-line-length 80 \
-            --disable C0114,C0115,C0116,R0801,R0903,R0904,R0913,R0914,R1721,R1737,W0107,W0212,W0223,W0231,W0511,W0621 \
-            model_signing/{hashing,manifest,serialization,signature,signing}
+          ruff check model_signing/{hashing,manifest,serialization,signature,signing}

--- a/model_signing/hashing/file.py
+++ b/model_signing/hashing/file.py
@@ -49,6 +49,7 @@ Example usage for `OpenedFileHasher`:
 import hashlib
 import pathlib
 from typing import BinaryIO
+
 from typing_extensions import override
 
 from model_signing.hashing import hashing

--- a/model_signing/hashing/file_test.py
+++ b/model_signing/hashing/file_test.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import pathlib
+
 import pytest
 
 from model_signing.hashing import file
 from model_signing.hashing import memory
-
 
 # some constants used throughout testing
 _HEADER: str = "Some "

--- a/model_signing/hashing/memory.py
+++ b/model_signing/hashing/memory.py
@@ -36,6 +36,7 @@ Or, passing the data directly in the constructor:
 """
 
 import hashlib
+
 from typing_extensions import override
 
 from model_signing.hashing import hashing

--- a/model_signing/install/requirements_dev.in
+++ b/model_signing/install/requirements_dev.in
@@ -1,2 +1,2 @@
-pylint
 pytype
+ruff

--- a/model_signing/install/requirements_dev_Darwin.txt
+++ b/model_signing/install/requirements_dev_Darwin.txt
@@ -4,18 +4,10 @@
 #
 #    pip-compile --generate-hashes --output-file=model_signing/install/requirements_dev_Darwin.txt --strip-extras model_signing/install/requirements_dev.in
 #
-astroid==3.2.4 \
-    --hash=sha256:0e14202810b30da1b735827f78f5157be2bbd4a7a59b7707ca0bfc2fb4c0063a \
-    --hash=sha256:413658a61eeca6202a59231abb473f932038fbcbf1666587f66d482083413a25
-    # via pylint
 attrs==23.2.0 \
     --hash=sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30 \
     --hash=sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1
     # via pytype
-dill==0.3.8 \
-    --hash=sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca \
-    --hash=sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7
-    # via pylint
 immutabledict==4.2.0 \
     --hash=sha256:d728b2c2410d698d95e6200237feb50a695584d20289ad3379a439aa3d90baba \
     --hash=sha256:e003fd81aad2377a5a758bf7e1086cf3b70b63e9a5cc2f46bce8d0a2b4727c5f
@@ -24,10 +16,6 @@ importlab==0.8.1 \
     --hash=sha256:124cfa00e8a34fefe8aac1a5e94f56c781b178c9eb61a1d3f60f7e03b77338d3 \
     --hash=sha256:b3893853b1f6eb027da509c3b40e6787e95dd66b4b66f1b3613aad77556e1465
     # via pytype
-isort==5.13.2 \
-    --hash=sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109 \
-    --hash=sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6
-    # via pylint
 jinja2==3.1.4 \
     --hash=sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369 \
     --hash=sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d
@@ -121,10 +109,6 @@ markupsafe==2.1.5 \
     --hash=sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd \
     --hash=sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68
     # via jinja2
-mccabe==0.7.0 \
-    --hash=sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325 \
-    --hash=sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e
-    # via pylint
 msgspec==0.18.6 \
     --hash=sha256:06acbd6edf175bee0e36295d6b0302c6de3aaf61246b46f9549ca0041a9d7177 \
     --hash=sha256:0e24539b25c85c8f0597274f11061c102ad6b0c56af053373ba4629772b407be \
@@ -186,22 +170,14 @@ ninja==1.11.1.1 \
     --hash=sha256:ecf80cf5afd09f14dcceff28cb3f11dc90fb97c999c89307aea435889cb66877 \
     --hash=sha256:fa2ba9d74acfdfbfbcf06fad1b8282de8a7a8c481d9dee45c859a8c93fcc1082
     # via pytype
-platformdirs==4.2.2 \
-    --hash=sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee \
-    --hash=sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3
-    # via pylint
-pycnite==2024.7.9 \
-    --hash=sha256:aece401e70e8b6bf369b3b33867c79a1b8bf584e68da9790de2f821503cebcf8 \
-    --hash=sha256:f07bea393ee4d5820013fae66db6cc091e8dc01fd3f6b367595108752f264872
+pycnite==2024.7.31 \
+    --hash=sha256:5125f1c95aef4a23b9bec3b32fae76873dcd46324fa68e39c10fa852ecdea340 \
+    --hash=sha256:9ff9c09d35056435b867e14ebf79626ca94b6017923a0bf9935377fa90d4cbb3
     # via pytype
 pydot==3.0.1 \
     --hash=sha256:43f1e878dc1ff7c1c2e3470a6999d4e9e97771c5c862440c2f0af0ba844c231f \
     --hash=sha256:e18cf7f287c497d77b536a3d20a46284568fea390776dface6eabbdf1b1b5efc
     # via pytype
-pylint==3.2.6 \
-    --hash=sha256:03c8e3baa1d9fb995b12c1dbe00aa6c4bcef210c2a2634374aedeb22fb4a8f8f \
-    --hash=sha256:a5d01678349454806cff6d886fb072294f56a58c4761278c97fb557d708e1eb3
-    # via -r model_signing/install/requirements_dev.in
 pyparsing==3.1.2 \
     --hash=sha256:a1bac0ce561155ecc3ed78ca94d3c9378656ad4c94c1270de543f621420f94ad \
     --hash=sha256:f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742
@@ -274,6 +250,26 @@ pyyaml==6.0.1 \
     --hash=sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d \
     --hash=sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f
     # via libcst
+ruff==0.5.5 \
+    --hash=sha256:00817603822a3e42b80f7c3298c8269e09f889ee94640cd1fc7f9329788d7bf8 \
+    --hash=sha256:187a60f555e9f865a2ff2c6984b9afeffa7158ba6e1eab56cb830404c942b0f3 \
+    --hash=sha256:3191317d967af701f1b73a31ed5788795936e423b7acce82a2b63e26eb3e89d6 \
+    --hash=sha256:3687d002f911e8a5faf977e619a034d159a8373514a587249cc00f211c67a091 \
+    --hash=sha256:4ad25dd9c5faac95c8e9efb13e15803cd8bbf7f4600645a60ffe17c73f60779b \
+    --hash=sha256:50f36d77f52d4c9c2f1361ccbfbd09099a1b2ea5d2b2222c586ab08885cf3445 \
+    --hash=sha256:605d589ec35d1da9213a9d4d7e7a9c761d90bba78fc8790d1c5e65026c1b9eaf \
+    --hash=sha256:696f18463b47a94575db635ebb4c178188645636f05e934fdf361b74edf1bb2d \
+    --hash=sha256:a09b43e02f76ac0145f86a08e045e2ea452066f7ba064fd6b0cdccb486f7c3e7 \
+    --hash=sha256:ac9dc814e510436e30d0ba535f435a7f3dc97f895f844f5b3f347ec8c228a523 \
+    --hash=sha256:af9bdf6c389b5add40d89b201425b531e0a5cceb3cfdcc69f04d3d531c6be74f \
+    --hash=sha256:cab904683bf9e2ecbbe9ff235bfe056f0eba754d0168ad5407832928d579e7ab \
+    --hash=sha256:cc5516bdb4858d972fbc31d246bdb390eab8df1a26e2353be2dbc0c2d7f5421a \
+    --hash=sha256:cfd7de17cef6ab559e9f5ab859f0d3296393bc78f69030967ca4d87a541b97a0 \
+    --hash=sha256:d0b856cb19c60cd40198be5d8d4b556228e3dcd545b4f423d1ad812bfdca5884 \
+    --hash=sha256:d40a8533ed545390ef8315b8e25c4bb85739b90bd0f3fe1280a29ae364cc55d8 \
+    --hash=sha256:f70737c157d7edf749bcb952d13854e8f745cec695a01bdc6e29c29c288fc36e \
+    --hash=sha256:fe26fc46fa8c6e0ae3f47ddccfbb136253c831c3289bba044befe68f467bfb16
+    # via -r model_signing/install/requirements_dev.in
 tabulate==0.9.0 \
     --hash=sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c \
     --hash=sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f
@@ -282,10 +278,6 @@ toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
     # via pytype
-tomlkit==0.13.0 \
-    --hash=sha256:08ad192699734149f5b97b45f1f18dad7eb1b6d16bc72ad0c2335772650d7b72 \
-    --hash=sha256:7075d3042d03b80f603482d69bf0c8f345c2b30e41699fd8883227f89972b264
-    # via pylint
 typing-extensions==4.12.2 \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8

--- a/model_signing/install/requirements_dev_Linux.txt
+++ b/model_signing/install/requirements_dev_Linux.txt
@@ -4,18 +4,10 @@
 #
 #    pip-compile --generate-hashes --output-file=model_signing/install/requirements_dev_Linux.txt --strip-extras model_signing/install/requirements_dev.in
 #
-astroid==3.2.4 \
-    --hash=sha256:0e14202810b30da1b735827f78f5157be2bbd4a7a59b7707ca0bfc2fb4c0063a \
-    --hash=sha256:413658a61eeca6202a59231abb473f932038fbcbf1666587f66d482083413a25
-    # via pylint
 attrs==23.2.0 \
     --hash=sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30 \
     --hash=sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1
     # via pytype
-dill==0.3.8 \
-    --hash=sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca \
-    --hash=sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7
-    # via pylint
 immutabledict==4.2.0 \
     --hash=sha256:d728b2c2410d698d95e6200237feb50a695584d20289ad3379a439aa3d90baba \
     --hash=sha256:e003fd81aad2377a5a758bf7e1086cf3b70b63e9a5cc2f46bce8d0a2b4727c5f
@@ -24,10 +16,6 @@ importlab==0.8.1 \
     --hash=sha256:124cfa00e8a34fefe8aac1a5e94f56c781b178c9eb61a1d3f60f7e03b77338d3 \
     --hash=sha256:b3893853b1f6eb027da509c3b40e6787e95dd66b4b66f1b3613aad77556e1465
     # via pytype
-isort==5.13.2 \
-    --hash=sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109 \
-    --hash=sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6
-    # via pylint
 jinja2==3.1.4 \
     --hash=sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369 \
     --hash=sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d
@@ -121,10 +109,6 @@ markupsafe==2.1.5 \
     --hash=sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd \
     --hash=sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68
     # via jinja2
-mccabe==0.7.0 \
-    --hash=sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325 \
-    --hash=sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e
-    # via pylint
 msgspec==0.18.6 \
     --hash=sha256:06acbd6edf175bee0e36295d6b0302c6de3aaf61246b46f9549ca0041a9d7177 \
     --hash=sha256:0e24539b25c85c8f0597274f11061c102ad6b0c56af053373ba4629772b407be \
@@ -186,22 +170,14 @@ ninja==1.11.1.1 \
     --hash=sha256:ecf80cf5afd09f14dcceff28cb3f11dc90fb97c999c89307aea435889cb66877 \
     --hash=sha256:fa2ba9d74acfdfbfbcf06fad1b8282de8a7a8c481d9dee45c859a8c93fcc1082
     # via pytype
-platformdirs==4.2.2 \
-    --hash=sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee \
-    --hash=sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3
-    # via pylint
-pycnite==2024.7.9 \
-    --hash=sha256:aece401e70e8b6bf369b3b33867c79a1b8bf584e68da9790de2f821503cebcf8 \
-    --hash=sha256:f07bea393ee4d5820013fae66db6cc091e8dc01fd3f6b367595108752f264872
+pycnite==2024.7.31 \
+    --hash=sha256:5125f1c95aef4a23b9bec3b32fae76873dcd46324fa68e39c10fa852ecdea340 \
+    --hash=sha256:9ff9c09d35056435b867e14ebf79626ca94b6017923a0bf9935377fa90d4cbb3
     # via pytype
 pydot==3.0.1 \
     --hash=sha256:43f1e878dc1ff7c1c2e3470a6999d4e9e97771c5c862440c2f0af0ba844c231f \
     --hash=sha256:e18cf7f287c497d77b536a3d20a46284568fea390776dface6eabbdf1b1b5efc
     # via pytype
-pylint==3.2.6 \
-    --hash=sha256:03c8e3baa1d9fb995b12c1dbe00aa6c4bcef210c2a2634374aedeb22fb4a8f8f \
-    --hash=sha256:a5d01678349454806cff6d886fb072294f56a58c4761278c97fb557d708e1eb3
-    # via -r model_signing/install/requirements_dev.in
 pyparsing==3.1.2 \
     --hash=sha256:a1bac0ce561155ecc3ed78ca94d3c9378656ad4c94c1270de543f621420f94ad \
     --hash=sha256:f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742
@@ -274,6 +250,26 @@ pyyaml==6.0.1 \
     --hash=sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d \
     --hash=sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f
     # via libcst
+ruff==0.5.5 \
+    --hash=sha256:00817603822a3e42b80f7c3298c8269e09f889ee94640cd1fc7f9329788d7bf8 \
+    --hash=sha256:187a60f555e9f865a2ff2c6984b9afeffa7158ba6e1eab56cb830404c942b0f3 \
+    --hash=sha256:3191317d967af701f1b73a31ed5788795936e423b7acce82a2b63e26eb3e89d6 \
+    --hash=sha256:3687d002f911e8a5faf977e619a034d159a8373514a587249cc00f211c67a091 \
+    --hash=sha256:4ad25dd9c5faac95c8e9efb13e15803cd8bbf7f4600645a60ffe17c73f60779b \
+    --hash=sha256:50f36d77f52d4c9c2f1361ccbfbd09099a1b2ea5d2b2222c586ab08885cf3445 \
+    --hash=sha256:605d589ec35d1da9213a9d4d7e7a9c761d90bba78fc8790d1c5e65026c1b9eaf \
+    --hash=sha256:696f18463b47a94575db635ebb4c178188645636f05e934fdf361b74edf1bb2d \
+    --hash=sha256:a09b43e02f76ac0145f86a08e045e2ea452066f7ba064fd6b0cdccb486f7c3e7 \
+    --hash=sha256:ac9dc814e510436e30d0ba535f435a7f3dc97f895f844f5b3f347ec8c228a523 \
+    --hash=sha256:af9bdf6c389b5add40d89b201425b531e0a5cceb3cfdcc69f04d3d531c6be74f \
+    --hash=sha256:cab904683bf9e2ecbbe9ff235bfe056f0eba754d0168ad5407832928d579e7ab \
+    --hash=sha256:cc5516bdb4858d972fbc31d246bdb390eab8df1a26e2353be2dbc0c2d7f5421a \
+    --hash=sha256:cfd7de17cef6ab559e9f5ab859f0d3296393bc78f69030967ca4d87a541b97a0 \
+    --hash=sha256:d0b856cb19c60cd40198be5d8d4b556228e3dcd545b4f423d1ad812bfdca5884 \
+    --hash=sha256:d40a8533ed545390ef8315b8e25c4bb85739b90bd0f3fe1280a29ae364cc55d8 \
+    --hash=sha256:f70737c157d7edf749bcb952d13854e8f745cec695a01bdc6e29c29c288fc36e \
+    --hash=sha256:fe26fc46fa8c6e0ae3f47ddccfbb136253c831c3289bba044befe68f467bfb16
+    # via -r model_signing/install/requirements_dev.in
 tabulate==0.9.0 \
     --hash=sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c \
     --hash=sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f
@@ -282,10 +278,6 @@ toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
     # via pytype
-tomlkit==0.13.0 \
-    --hash=sha256:08ad192699734149f5b97b45f1f18dad7eb1b6d16bc72ad0c2335772650d7b72 \
-    --hash=sha256:7075d3042d03b80f603482d69bf0c8f345c2b30e41699fd8883227f89972b264
-    # via pylint
 typing-extensions==4.12.2 \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8

--- a/model_signing/manifest/manifest.py
+++ b/model_signing/manifest/manifest.py
@@ -56,6 +56,7 @@ from collections.abc import Iterable, Iterator
 import dataclasses
 import pathlib
 from typing import Self
+
 from typing_extensions import override
 
 from model_signing.hashing import hashing

--- a/model_signing/manifest/manifest_test.py
+++ b/model_signing/manifest/manifest_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pathlib
+
 import pytest
 
 from model_signing.hashing import hashing

--- a/model_signing/pyproject.toml
+++ b/model_signing/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.ruff]
+line-length = 80
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["B", "E", "F", "I", "N", "PLC", "PLE", "SIM", "W"]
+ignore = ["B024"]
+
+[tool.ruff.lint.isort]
+force-single-line = true
+force-sort-within-sections = true
+single-line-exclusions = ["collections.abc", "typing"]

--- a/model_signing/serialization/serialize_by_file.py
+++ b/model_signing/serialization/serialize_by_file.py
@@ -98,10 +98,7 @@ def _ignored(path: pathlib.Path, ignore_paths: Iterable[pathlib.Path]) -> bool:
     Returns:
         Whether or not the provided path should be ignored.
     """
-    for ignore_path in ignore_paths:
-        if path.is_relative_to(ignore_path):
-            return True
-    return False
+    return any(path.is_relative_to(ignore_path) for ignore_path in ignore_paths)
 
 class FilesSerializer(serialization.Serializer):
     """Generic file serializer.

--- a/model_signing/serialization/serialize_by_file_shard_test.py
+++ b/model_signing/serialization/serialize_by_file_shard_test.py
@@ -693,7 +693,6 @@ class TestManifestSerializer:
         )
         manifest1 = serializer.serialize(sample_model_folder)
         ignore_path = test_support.get_first_directory(sample_model_folder)
-        ignored_file_count = test_support.count_files(ignore_path)
         manifest2 = serializer.serialize(
             sample_model_folder, ignore_paths=[ignore_path]
         )

--- a/model_signing/signature/fake.py
+++ b/model_signing/signature/fake.py
@@ -20,8 +20,8 @@ from sigstore_protobuf_specs.dev.sigstore.bundle import v1 as bundle_pb
 from sigstore_protobuf_specs.dev.sigstore.common import v1 as common_pb
 from sigstore_protobuf_specs.io import intoto as intoto_pb
 
-from model_signing.signature.signing import Signer
 from model_signing.signature.encoding import PAYLOAD_TYPE
+from model_signing.signature.signing import Signer
 from model_signing.signature.verifying import Verifier
 
 

--- a/model_signing/signature/key.py
+++ b/model_signing/signature/key.py
@@ -27,8 +27,8 @@ from sigstore_protobuf_specs.io import intoto as intoto_pb
 
 from model_signing.signature import encoding
 from model_signing.signature.signing import Signer
-from model_signing.signature.verifying import Verifier
 from model_signing.signature.verifying import VerificationError
+from model_signing.signature.verifying import Verifier
 
 
 def load_ec_private_key(

--- a/model_signing/signature/key_test.py
+++ b/model_signing/signature/key_test.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 # flake8: noqa: E712
 import pathlib
-import pytest
 
-from in_toto_attestation.v1 import statement
 from in_toto_attestation.v1 import resource_descriptor as res_desc
+from in_toto_attestation.v1 import statement
+import pytest
 
 from model_signing.signature.key import ECKeySigner
 from model_signing.signature.key import ECKeyVerifier

--- a/model_signing/signature/pki.py
+++ b/model_signing/signature/pki.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 """This package provides the functionality to sign and verify models
 with certificates."""
-from typing import Optional
-from typing import Self
+from typing import Optional, Self
 
 import certifi
-
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -31,8 +29,8 @@ from model_signing.signature.key import ECKeySigner
 from model_signing.signature.key import ECKeyVerifier
 from model_signing.signature.key import load_ec_private_key
 from model_signing.signature.signing import Signer
-from model_signing.signature.verifying import Verifier
 from model_signing.signature.verifying import VerificationError
+from model_signing.signature.verifying import Verifier
 
 
 def _load_single_cert(path: str) -> x509.Certificate:

--- a/model_signing/signature/sigstore.py
+++ b/model_signing/signature/sigstore.py
@@ -18,16 +18,16 @@ from typing import Optional
 from absl import logging as log
 from in_toto_attestation.v1 import statement
 from sigstore import dsse
+from sigstore import models as sig_models
 from sigstore import oidc
 from sigstore import sign
-from sigstore import models as sig_models
-from sigstore.verify import verifier as sig_verifier
 from sigstore.verify import policy as sig_policy
+from sigstore.verify import verifier as sig_verifier
 from sigstore_protobuf_specs.dev.sigstore.bundle import v1 as bundle_pb
 
 from model_signing.signature.signing import Signer
-from model_signing.signature.verifying import Verifier
 from model_signing.signature.verifying import VerificationError
+from model_signing.signature.verifying import Verifier
 
 
 class SigstoreSigner(Signer):

--- a/model_signing/signing/as_bytes.py
+++ b/model_signing/signing/as_bytes.py
@@ -19,6 +19,7 @@ the hash computed from somewhere else and want to avoid the in-toto types.
 """
 
 from typing import Self
+
 from typing_extensions import override
 
 from model_signing.manifest import manifest as manifest_module

--- a/model_signing/signing/empty_signing.py
+++ b/model_signing/signing/empty_signing.py
@@ -22,6 +22,7 @@ done from outside the library).
 
 import pathlib
 from typing import Self
+
 from typing_extensions import override
 
 from model_signing.manifest import manifest

--- a/model_signing/signing/empty_signing_test.py
+++ b/model_signing/signing/empty_signing_test.py
@@ -14,6 +14,7 @@
 
 import pathlib
 from typing import Self
+
 import pytest
 from typing_extensions import override
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Configure `ruff` with a barebones `pyproject.toml` to address the conversion mentioned in #232. I spent the time to do the switch now so I would stop messing up import ordering.

In terms of the rules selected, https://github.com/sigstore/model-transparency/commit/7f85551a332806989291ab144a0c2264c2a72f82 talks about the motivation for picking them, but I'm happy to adjust as needed, or include the reasons in the config file itself.
```toml
select = [
    "B", # flake8-bugbear
    "E", # pycodestyle
    ...
]
```

I wasn't sure where to place the `pyproject.toml` but we have options (including making it a `.ruff.toml` for now):

1. The repository root, which would allow us to configure `ruff` in one spot for both `model_signing` and `slsa_for_models`. The `tool.ruff` section can extend other `pyproject.toml`s, so if we had a `pyproject.toml` for each project they [could inherit `ruff` settings](https://docs.astral.sh/ruff/configuration/#config-file-discovery).
2. The `model_signing` directory (which is where it currently is in this PR).

For reviewers, I recommend going commit by commit, I tried to organize them in reviewable chunks.

@mihaimaruseac does this address the comments you left in #232?
> Doing this because the pylint annotation in https://github.com/sigstore/model-transparency/pull/230 are ignored by flake8.
 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

NONE