### PR TITLE
fix issuer creation when provided an OIDC issuer

### DIFF
--- a/model_signing/signing/sigstore.py
+++ b/model_signing/signing/sigstore.py
@@ -118,7 +118,7 @@ class SigstoreSigner(signing.Signer):
         else:
           self._signing_context = sigstore_signer.SigningContext.production()
           if oidc_issuer is not None:
-              self._issuer = sigstore_oidc.Issuer.production(oidc_issuer)
+              self._issuer = sigstore_oidc.Issuer(oidc_issuer)
           else:
               self._issuer = sigstore_oidc.Issuer.production()
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
`sigstore.oidc.Issuer.production()` doesn't accept arguments, but the class initializer does. This should have been caught by a linter, but we have two upstream issues working against us.

pylint's `too-many-function-args` (E1121) would have caught this, but we switched to ruff in f8238f1ce41a1fdf08c82c0d2bed0fe898d63665 which doesn't support E1121 yet.
https://www.github.com/astral-sh/ruff/issues/970

pytype doesn't use library type information unless a stub is present in the typeshed repo (sigstore-python follows PEP 561 instead). https://www.github.com/google/pytype/issues/151


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

NONE