### PR TITLE
enable flake8-pytest-style linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,7 +66,7 @@ jobs:
           pip install -r model_signing/install/requirements_test_Linux.txt
           pip install -r model_signing/install/requirements_dev_Linux.txt
           # TODO: https://github.com/sigstore/model-transparency/issues/231 - Support all repo
-          pytype --keep-going model_signing/{hashing,manifest,serialization,signature,signing}
+          pytype --keep-going model_signing/{conftest.py,hashing,manifest,serialization,signature,signing}
 
   ruff-lint:
     runs-on: ubuntu-latest
@@ -86,4 +86,4 @@ jobs:
           pip install -r model_signing/install/requirements_test_Linux.txt
           pip install -r model_signing/install/requirements_dev_Linux.txt
           # TODO: https://github.com/sigstore/model-transparency/issues/231 - Support all repo
-          ruff check model_signing/{hashing,manifest,serialization,signature,signing}
+          ruff check model_signing/{conftest.py,hashing,manifest,serialization,signature,signing}

--- a/model_signing/conftest.py
+++ b/model_signing/conftest.py
@@ -16,6 +16,7 @@
 
 import os
 import pathlib
+
 import pytest
 
 from model_signing import test_support
@@ -106,7 +107,9 @@ def deep_model_folder(tmp_path_factory):
     return model_root
 
 @pytest.fixture
-def symlink_model_folder(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
+def symlink_model_folder(
+    tmp_path_factory: pytest.TempPathFactory
+) -> pathlib.Path:
     """A model folder with a symlink to an external file."""
     external_file = tmp_path_factory.mktemp("external") / "file"
     external_file.write_bytes(test_support.KNOWN_MODEL_TEXT)

--- a/model_signing/pyproject.toml
+++ b/model_signing/pyproject.toml
@@ -3,8 +3,11 @@ line-length = 80
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["B", "E", "F", "I", "N", "PLC", "PLE", "SIM", "W"]
+select = ["B", "E", "F", "I", "N", "PLC", "PLE", "PT", "SIM", "W"]
 ignore = ["B024"]
+
+[tool.ruff.lint.flake8-pytest-style]
+fixture-parentheses = false
 
 [tool.ruff.lint.isort]
 force-single-line = true

--- a/model_signing/serialization/serialize_by_file_shard_test.py
+++ b/model_signing/serialization/serialize_by_file_shard_test.py
@@ -306,7 +306,9 @@ class TestDigestSerializer:
         serializer = serialize_by_file_shard.DigestSerializer(
             self._hasher_factory, memory.SHA256()
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match="Cannot use '.+' because it is a symlink."
+        ):
             _ = serializer.serialize(symlink_model_folder)
 
     def test_ignore_list_respects_directories(self, sample_model_folder):
@@ -679,7 +681,9 @@ class TestManifestSerializer:
         serializer = serialize_by_file_shard.ManifestSerializer(
             self._hasher_factory
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match="Cannot use '.+' because it is a symlink."
+        ):
             _ = serializer.serialize(symlink_model_folder)
 
     def test_shard_to_string(self):

--- a/model_signing/serialization/serialize_by_file_test.py
+++ b/model_signing/serialization/serialize_by_file_test.py
@@ -283,7 +283,9 @@ class TestDigestSerializer:
         serializer = serialize_by_file.DigestSerializer(
             file_hasher, memory.SHA256
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match="Cannot use '.+' because it is a symlink."
+        ):
             _ = serializer.serialize(symlink_model_folder)
 
     def test_ignore_list_respects_directories(self, sample_model_folder):
@@ -565,7 +567,9 @@ class TestManifestSerializer:
 
     def test_symlinks_disallowed_by_default(self, symlink_model_folder):
         serializer = serialize_by_file.ManifestSerializer(self._hasher_factory)
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match="Cannot use '.+' because it is a symlink."
+        ):
             _ = serializer.serialize(symlink_model_folder)
 
     def test_ignore_list_respects_directories(self, sample_model_folder):


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Since we use `pytest`, we may as well enable the associated `flake8` linter. It caught [one best practice](https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/) I didn't follow in #251. Additionally, it's one step closer to completing #231 as the linter now checks our `conftest.py`

With regard to `fixture-parentheses = false` configuration, both `@pytest.fixture` and `@pytest.fixture()` are valid, but the default settings expect parentheses and our code doesn't. We could also disable the rule entirely, but this will enforce consistency.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

NONE
