### PR TITLE
Add `.coverage` to `.gitignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.coverage
 .pytest_cache/
 .pytype/
 .ruff_cache/


### PR DESCRIPTION
#### Summary
This file gets generated when testing with coverage data (`hatch test -c`). I missed adding it to `.gitignore` in #283 because I didn't run testing with coverage locally. Fixing the issue now.

(As a side effect, this helps tests that we properly configured the required GHA checks for the repo).

#### Release Note
NONE

#### Documentation
NONE