### PR TITLE
Update link to documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ keywords = [
 [project.urls]
 Homepage = "https://pypi.org/project/model-signing/"
 Changelog = "https://github.com/sigstore/model-transparency/blob/main/CHANGELOG.md"
-# TODO: https://github.com/sigstore/model-transparency/pull/279 - Documentation = "...."
+Documentation = "https://sigstore.github.io/model-transparency/model_signing.html"
 Source = "https://github.com/sigstore/model-transparency"
 Issues = "https://github.com/sigstore/model-transparency/issues"
 PyPI = "https://pypi.org/project/model-signing/"


### PR DESCRIPTION
#### Summary
After #209 we now have documentation available at https://sigstore.github.io/model-transparency/model_signing.html, so we can provide this link in the wheel/PyPI page.

#### Release Note
NONE
#### Documentation
This is just a link to the documentation, but we need to clean it up in the near future.