### PR TITLE
Modification of CI Workflow to enhance Coverage reporting

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -41,4 +41,41 @@ jobs:
     - name: Set up Hatch
       uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
     - name: Run unit tests (with coverage report at the end)
-      run: hatch test -c -py ${{ matrix.python-version }}
+      run: |
+        set -euxo pipefail
+        if [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.python-version }}" == "3.11" ]]; then
+          hatch test -c -py ${{ matrix.python-version }} | tee > cov.txt
+        else
+          hatch test -c -py ${{ matrix.python-version }}
+        fi
+
+    - name: Highlight missing lines
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      run: |
+        set -euxo pipefail
+        awk '/Name/{flag=1; next} /TOTAL/{flag=0; next} flag && !/^[-]+$/' cov.txt | while IFS= read -r line; do
+          # Extract file name and missing ranges
+          file_name=$(echo "$line" | awk '{print $1}')
+          missing_lines=$(echo "$line" | awk '{for (i=5; i<=NF; i++) printf $i " "; print ""}')
+          # Process each range
+          for range in $missing_lines; do
+            # Trim leading and trailing whitespace
+            range=$(echo "$range" | xargs)
+            line_start=""
+            line_end=""
+            message=""
+            if [[ "$range" == *"-"* ]]; then
+              # Split range into start and end
+              line_start=$(echo "$range" | cut -d'-' -f1)
+              line_end=$(echo "$range" | cut -d'-' -f2)
+              message="The following lines were not covered in your tests: $line_start to $line_end"
+            else
+              # Single line number
+              line_start=$range
+              line_end=$range
+              message="The following line was not covered in your tests: $line_start"
+            fi
+
+            echo "::warning file=$file_name,line=$line_start,endLine=$line_end::$message"
+          done
+        done


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

The problem is that the coverage report is being displayed on the command line, and it would be ideal to have a GitHub formatted output that shows up in code files in the PR that highlights the lines of code that were not covered in the unit test CI workflow. Doing so, it would assist reviewers in ensuring that the code coverage is high.

The unit_tests workflow has been modified to:
- Create a coverage file only if the specified OS and python version finish the test
- Run a step to process the file and extract the file names and the missed lines/ranges and highlight the lines using workflow commands

Resolves: #288


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
