### PR TITLE
Don't run some GHA workflows in forks.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   analyze:
     name: Analyze
+    if: github.repository == 'sigstore/model-transparency'  # Don't do this in forks
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -24,4 +24,5 @@ permissions:
 jobs:
   dependency-review:
     name: License and Vulnerability Scan
+    if: github.repository == 'sigstore/model-transparency'  # Don't do this in forks
     uses: sigstore/community/.github/workflows/reusable-dependency-review.yml@8cc8d600fbf3012b9d9d84a499423fa96afa3765

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'sigstore/model-transparency'  # Don't do this in forks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,6 +34,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
+    if: github.repository == 'sigstore/model-transparency'  # Don't do this in forks
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.


### PR DESCRIPTION
#### Summary
Some workflows can only run without error while triggered from this repo. Whenever they get triggered from a fork they fail. So, prevent them from running on forks.

#### Release Note
NONE

#### Documentation
NONE