### PR TITLE
 enable pyupgrade (UP) linter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,9 +112,13 @@ line-ending = "lf"
 skip-magic-trailing-comma = true
 
 [tool.ruff.lint]
-select = ["B", "D", "E", "F", "I", "N", "PLC", "PLE", "PT", "SIM", "W"]
-# TODO: selectively enable back most of these in subsequent PRs
-ignore = ["B024", "D100", "D101", "D102", "D103", "D104", "D105", "D107", "D417"]
+select = ["B", "D", "E", "F", "I", "N", "PLC", "PLE", "PT", "SIM", "UP", "W"]
+ignore = [
+  # TODO: selectively enable back most of these in subsequent PRs
+  "B024", "D100", "D101", "D102", "D103", "D104", "D105", "D107", "D417",
+  # Unnecessary arguments can help with clarity
+  "UP012", "UP015"
+]
 
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"

--- a/src/model_signing/model.py
+++ b/src/model_signing/model.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable, Iterable
 import pathlib
-from typing import Callable, Iterable, TypeAlias
+from typing import TypeAlias
 
 from model_signing.manifest import manifest
 from model_signing.serialization import serialization

--- a/src/model_signing/serialization/serialize_by_file_shard.py
+++ b/src/model_signing/serialization/serialize_by_file_shard.py
@@ -69,8 +69,7 @@ def _endpoints(step: int, end: int) -> Iterable[int]:
     Yields:
         Values in the range, from `step` and up to `end`.
     """
-    for value in range(step, end, step):
-        yield value
+    yield from range(step, end, step)
     yield end
 
 

--- a/src/model_signing/signature/key.py
+++ b/src/model_signing/signature/key.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """Functionality to sign and verify models with keys."""
 
-from typing import Optional
-
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.hashes import SHA256
@@ -32,7 +30,7 @@ from model_signing.signature.verifying import Verifier
 
 
 def load_ec_private_key(
-    path: str, password: Optional[str] = None
+    path: str, password: str | None = None
 ) -> ec.EllipticCurvePrivateKey:
     private_key: ec.EllipticCurvePrivateKey
     with open(path, "rb") as fd:
@@ -50,7 +48,7 @@ class ECKeySigner(Signer):
         self._private_key = private_key
 
     @classmethod
-    def from_path(cls, private_key_path: str, password: Optional[str] = None):
+    def from_path(cls, private_key_path: str, password: str | None = None):
         private_key = load_ec_private_key(private_key_path, password)
         return cls(private_key)
 

--- a/src/model_signing/signature/pki.py
+++ b/src/model_signing/signature/pki.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Functionality to sign and verify models with certificates."""
 
-from typing import Optional, Self
+from typing import Self
 
 import certifi
 from cryptography import x509
@@ -67,10 +67,8 @@ class PKISigner(Signer):
         cert_pub_key = self._signing_cert.public_key()
         if pub_key != cert_pub_key:
             raise ValueError(
-                (
-                    "the private key's public key does not match the"
-                    " signing certificates public key"
-                )
+                "the private key's public key does not match the"
+                " signing certificates public key"
             )
         self._cert_chain = cert_chain
 
@@ -129,9 +127,7 @@ class PKIVerifier(Verifier):
             self._store.add_cert(ssl_crypto.X509.from_cryptography(c))
 
     @classmethod
-    def from_paths(
-        cls, root_cert_paths: Optional[list[str]] | None = None
-    ) -> Self:
+    def from_paths(cls, root_cert_paths: list[str] | None = None) -> Self:
         crypto_trust_roots: list[x509.Certificate] = []
         if root_cert_paths:
             crypto_trust_roots = _load_multiple_certs(root_cert_paths)
@@ -171,14 +167,14 @@ class PKIVerifier(Verifier):
         )
         if not usage.value.digital_signature:
             raise VerificationError(
-                ("the certificate is not valid for digital signature usage")
+                "the certificate is not valid for digital signature usage"
             )
         ext_usage = signing_cert_crypto.extensions.get_extension_for_class(
             x509.ExtendedKeyUsage
         )
         if crypto_oid.ExtendedKeyUsageOID.CODE_SIGNING not in ext_usage.value:
             raise VerificationError(
-                ("the certificate is not valid for code signing usage")
+                "the certificate is not valid for code signing usage"
             )
 
         # Verify the contents with a key verifier


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
The main rule I'm interested in is [UP035](https://docs.astral.sh/ruff/rules/deprecated-import/), which helps prevent using
deprecated imports. Specifically some of the `typing` imports which now
live in `collections.abc`.

I disabled two rules ([UP012](https://docs.astral.sh/ruff/rules/unnecessary-encode-utf8/), [UP015](https://docs.astral.sh/ruff/rules/redundant-open-modes/)) which consider some optional args as unnecessary,
as there were many occurrences and it seemed opinionated. **But happy to re-add if desired**.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

NONE
