### PR TITLE
Fix SLSA for ML workflows

### DIFF
--- a/.github/workflows/slsa_for_ml.yml
+++ b/.github/workflows/slsa_for_ml.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false # Don't cancel other jobs if one fails
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest] ## , macos-latest, windows-latest]
         include:
           - os: macos-latest
             os_family: Darwin
@@ -57,8 +57,8 @@ jobs:
             os_family: Windows
     outputs:
       hash-ubuntu-latest: ${{ steps.hash.outputs.hash-ubuntu-latest }}
-      hash-macos-latest: ${{ steps.hash.outputs.hash-macos-latest }}
-      hash-windows-latest: ${{ steps.hash.outputs.hash-windows-latest }}
+      # hash-macos-latest: ${{ steps.hash.outputs.hash-macos-latest }}
+      # hash-windows-latest: ${{ steps.hash.outputs.hash-windows-latest }}
     steps:
     - run: git config --global core.autocrlf input
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false # Don't cancel other jobs if one fails
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest] #, macos-latest, windows-latest]
     permissions:
       actions: read
       id-token: write

--- a/.github/workflows/slsa_for_ml.yml
+++ b/.github/workflows/slsa_for_ml.yml
@@ -49,12 +49,12 @@ jobs:
       matrix:
         os: [ubuntu-latest] ## , macos-latest, windows-latest]
         include:
-          - os: macos-latest
-            os_family: Darwin
+          #- os: macos-latest
+          #  os_family: Darwin
           - os: ubuntu-latest
             os_family: Linux
-          - os: windows-latest
-            os_family: Windows
+          #- os: windows-latest
+          #  os_family: Windows
     outputs:
       hash-ubuntu-latest: ${{ steps.hash.outputs.hash-ubuntu-latest }}
       # hash-macos-latest: ${{ steps.hash.outputs.hash-macos-latest }}

--- a/slsa_for_models/pytorch_cifar10.py
+++ b/slsa_for_models/pytorch_cifar10.py
@@ -15,6 +15,7 @@
 import torch
 import torch.nn as nn
 
+
 # We will do a lazy import for these 5 modules, exploiting Python's symbol
 # resolution. The lazy import is needed to make sure we only import PyTorch
 # libraries only if we want to train a PyTorch model.
@@ -111,8 +112,6 @@ def create_model():
 
     Returns the model.
     """
-
-
     return MyModel()
 
 

--- a/slsa_for_models/pytorch_cifar10.py
+++ b/slsa_for_models/pytorch_cifar10.py
@@ -12,16 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import torch
+import torch.nn as nn
 
-# We will do a lazy import for these 7 modules, exploiting Python's symbol
+# We will do a lazy import for these 5 modules, exploiting Python's symbol
 # resolution. The lazy import is needed to make sure we only import PyTorch
 # libraries only if we want to train a PyTorch model.
-torch = None
-nn = None
 functional = None
 optim = None
 torchvision = None
 transforms = None
+
+
+class MyModel(nn.Module):
+    """Train a PyTorch model.
+
+    Based on tutorial from
+    https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+
+    def forward(self, x):
+        x = self.pool(functional.relu(self.conv1(x)))
+        x = self.pool(functional.relu(self.conv2(x)))
+        x = torch.flatten(x, 1)
+        x = functional.relu(self.fc1(x))
+        x = functional.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x
 
 
 def pretraining():
@@ -30,14 +56,10 @@ def pretraining():
     Does the lazy loading of TensorFlow too, to prevent compatibility issues
     with mixing TensorFlow and PyTorch imports.
     """
-    global torch
-    global nn
     global functional
     global optim
     global torchvision
     global transforms
-    import torch
-    import torch.nn as nn
     import torch.nn.functional as functional
     import torch.optim as optim
     import torchvision
@@ -90,27 +112,6 @@ def create_model():
     Returns the model.
     """
 
-    # Train a model based on tutorial from
-    # https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html.
-    # We inline the class to be able to use lazy loading of PyTorch modules.
-    class MyModel(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.conv1 = nn.Conv2d(3, 6, 5)
-            self.pool = nn.MaxPool2d(2, 2)
-            self.conv2 = nn.Conv2d(6, 16, 5)
-            self.fc1 = nn.Linear(16 * 5 * 5, 120)
-            self.fc2 = nn.Linear(120, 84)
-            self.fc3 = nn.Linear(84, 10)
-
-        def forward(self, x):
-            x = self.pool(functional.relu(self.conv1(x)))
-            x = self.pool(functional.relu(self.conv2(x)))
-            x = torch.flatten(x, 1)
-            x = functional.relu(self.fc1(x))
-            x = functional.relu(self.fc2(x))
-            x = self.fc3(x)
-            return x
 
     return MyModel()
 

--- a/slsa_for_models/tensorflow_cifar10.py
+++ b/slsa_for_models/tensorflow_cifar10.py
@@ -121,7 +121,7 @@ def train_model(model, train, test):
         epochs=16,
         validation_data=test,
         shuffle=True,
-        verbose=2,
+        verbose=0,
     )
 
 

--- a/slsa_for_models/tensorflow_cifar10.py
+++ b/slsa_for_models/tensorflow_cifar10.py
@@ -115,7 +115,13 @@ def train_model(model, train, test):
     """
     x, y = train
     model.fit(
-        x, y, batch_size=256, epochs=16, validation_data=test, shuffle=True
+        x,
+        y,
+        batch_size=256,
+        epochs=16,
+        validation_data=test,
+        shuffle=True,
+        verbose=2,
     )
 
 


### PR DESCRIPTION
#### Summary
Note related to the model signing library/CLI, but we need to have the SLSA workflows working for some demos. We only need Linux support now and it's somewhat costly to fix Mac and Windows now. So, let's punt those for later.

Windows is broken due to some encoding issue from one library that updated below us. Mac is broken because we need to change the way artifacts are uploaded between the 2 jobs.

Needed to do some minor changes to TF and PT model training libraries to make model training finish.

Dependencies are now no longer updated, so there should be no more breakages until we can come back to the SLSA workstream.

Tested by running the workflow in the 6 scenarios in my fork.

#### Release Note
NONE

#### Documentation
NONE