### PR TITLE
Add support for Python3.10

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false # Don't cancel other jobs if one fails
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Set up Hatch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Development Status :: 3 - Alpha",
@@ -30,7 +31,7 @@ dependencies = [
   "sigstore",
   "typing_extensions",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 keywords = [
   "machine learning",
   "artificial intelligence",
@@ -61,7 +62,7 @@ parallel = true
 randomize = true
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.11", "3.12"]
+python = ["3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.docs]
 description = """Custom environment for pdoc.

--- a/src/model_signing/hashing/file.py
+++ b/src/model_signing/hashing/file.py
@@ -199,18 +199,18 @@ class OpenedFileHasher(FileHasher):
             digest = hashlib.file_digest(self._fd, self._algorithm)
             # pytype: enable=wrong-arg-types
             return hashing.Digest(self.digest_name, digest.digest())
-        else:
-            # Polyfill for Python 3.10
-            # See https://github.com/python/cpython/blob/4deb32a99292a3b1f6b773f6f96f1a8990a19fe0/Lib/hashlib.py#L195-L238
-            hasher = hashlib.new(self._algorithm)
-            buffer = bytearray(2**18)
-            view = memoryview(buffer)
-            while True:
-                size = self._fd.readinto(buffer)
-                if size == 0:
-                    break
-                hasher.update(view[:size])
-            return hashing.Digest(self.digest_name, hasher.digest())
+
+        # Polyfill for Python 3.10
+        # https://github.com/python/cpython/blob/4deb32a992/Lib/hashlib.py#L195
+        hasher = hashlib.new(self._algorithm)
+        buffer = bytearray(2**18)
+        view = memoryview(buffer)
+        while True:
+            size = self._fd.readinto(buffer)
+            if size == 0:
+                break
+            hasher.update(view[:size])
+        return hashing.Digest(self.digest_name, hasher.digest())
 
     @property
     @override

--- a/src/model_signing/manifest/manifest.py
+++ b/src/model_signing/manifest/manifest.py
@@ -55,11 +55,17 @@ import abc
 from collections.abc import Iterable, Iterator
 import dataclasses
 import pathlib
-from typing import Self
+import sys
 
 from typing_extensions import override
 
 from model_signing.hashing import hashing
+
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/model_signing/signing/as_bytes.py
+++ b/src/model_signing/signing/as_bytes.py
@@ -18,12 +18,18 @@ In general, this should only be used if we want to sign a model where we have
 the hash computed from somewhere else and want to avoid the in-toto types.
 """
 
-from typing import Self
+import sys
 
 from typing_extensions import override
 
 from model_signing.manifest import manifest as manifest_module
 from model_signing.signing import signing
+
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class BytesPayload(signing.SigningPayload):

--- a/src/model_signing/signing/empty_signing.py
+++ b/src/model_signing/signing/empty_signing.py
@@ -21,12 +21,18 @@ done from outside the library).
 """
 
 import pathlib
-from typing import Self
+import sys
 
 from typing_extensions import override
 
 from model_signing.manifest import manifest
 from model_signing.signing import signing
+
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class EmptySigningPayload(signing.SigningPayload):

--- a/src/model_signing/signing/in_toto.py
+++ b/src/model_signing/signing/in_toto.py
@@ -20,7 +20,8 @@ envelope format is DSSE, see https://github.com/secure-systems-lab/dsse.
 """
 
 import pathlib
-from typing import Any, Final, Self
+import sys
+from typing import Any, Final
 
 from in_toto_attestation.v1 import statement
 from typing_extensions import override
@@ -29,6 +30,12 @@ from model_signing.hashing import hashing
 from model_signing.hashing import memory
 from model_signing.manifest import manifest as manifest_module
 from model_signing.signing import signing
+
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class IntotoPayload(signing.SigningPayload):

--- a/src/model_signing/signing/in_toto_signature.py
+++ b/src/model_signing/signing/in_toto_signature.py
@@ -16,7 +16,7 @@
 
 import json
 import pathlib
-from typing import Self
+import sys
 
 from sigstore_protobuf_specs.dev.sigstore.bundle import v1 as bundle_pb
 from typing_extensions import override
@@ -26,6 +26,12 @@ from model_signing.signature import signing as signature_signing
 from model_signing.signature import verifying as signature_verifying
 from model_signing.signing import in_toto
 from model_signing.signing import signing
+
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class IntotoSignature(signing.Signature):

--- a/src/model_signing/signing/signing.py
+++ b/src/model_signing/signing/signing.py
@@ -43,9 +43,15 @@ payload and then expand that to a `manifest.Manifest` subclass.
 
 import abc
 import pathlib
-from typing import Self
+import sys
 
 from model_signing.manifest import manifest
+
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class SigningPayload(metaclass=abc.ABCMeta):

--- a/src/model_signing/signing/sigstore.py
+++ b/src/model_signing/signing/sigstore.py
@@ -16,7 +16,7 @@
 
 import json
 import pathlib
-from typing import Self
+import sys
 
 from google.protobuf import json_format
 from sigstore import dsse as sigstore_dsse
@@ -31,6 +31,12 @@ from model_signing.manifest import manifest
 from model_signing.signing import as_bytes
 from model_signing.signing import in_toto
 from model_signing.signing import signing
+
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 _IN_TOTO_JSON_PAYLOAD_TYPE: str = "application/vnd.in-toto+json"

--- a/tests/signing/empty_signing_test.py
+++ b/tests/signing/empty_signing_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pathlib
-from typing import Self
+import sys
 
 import pytest
 from typing_extensions import override
@@ -23,6 +23,12 @@ from model_signing.manifest import manifest
 from model_signing.signing import empty_signing
 from model_signing.signing import signing
 from tests import test_support
+
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class TestEmptySigningPayload:

--- a/tests/signing/sigstore_test.py
+++ b/tests/signing/sigstore_test.py
@@ -16,7 +16,7 @@
 
 import json
 import pathlib
-from typing import Self
+import sys
 from unittest import mock
 
 import pytest
@@ -29,6 +29,12 @@ from model_signing.signing import as_bytes
 from model_signing.signing import empty_signing
 from model_signing.signing import in_toto
 from model_signing.signing import sigstore
+
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class MockedSigstoreBundle:


### PR DESCRIPTION
#### Summary
Suport Python 3.10 so that we can use the library in Google Colab without having to reinstall.

We only need 2 changes:
- `Self` needs to be imported from `typing_extensions`
- `hashlib.file_digest` needs to be implemented manually. I backported the implementation that Python uses, adapted to our scenario.

#### Release Note
NONE
#### Documentation
NONE