### PR TITLE
Add trusted publishing workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,17 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Documentation
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release
+
+on:
+  tags:
+    - v*
+
+permissions: {}
+
+jobs:
+  build_wheel:
+    name: Build the wheel
+    if: github.repository == 'sigstore/model-transparency'  # Don't do this in forks
+    runs-on: ubuntu-latest  # Use matrix when we have OS specific pieces
+    steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - name: Set up Hatch
+      uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
+    - name: Build artifacts
+      run: hatch build
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+      with:
+        path: dist/
+        name: dist.zip
+        if-no-files-found: error
+        retention-days: 1
+
+  publish_release_to_pypi:
+    name: Publish release to PyPI
+    needs: [build_wheel]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/model-signing/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: dist.zip
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+
+  # TODO: Create and publish release notes
+  # TODO: Generate SLSA provenance for the wheels
+  # TODO: Sign artifacts with sigstore and publish to release page

--- a/src/model_signing/__init__.py
+++ b/src/model_signing/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.1-alpha"
+__version__ = "0.0.2-alpha"


### PR DESCRIPTION
#### Summary
Preparing to add releases to PyPI via Trusted Publishing, via GHA.

There are more steps we can do during the release, but for now they are marked as TODOs. When we get closer to v1 release we will have all of them, but right now they're blocked on having good documentation/release notes support too. Need to see if the following two sections here are used.

PS: Updated the version to the next, to try another release.

#### Release Note
NONE
#### Documentation
NONE