### PR TITLE
Change release trigger to be `release` instead of the wrong `tags`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,9 @@
 name: Release
 
 on:
-  tags:
-    - v*
+  push:
+    tags:
+      - v*
 
 permissions: {}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - v*
+  release:
+    types:
+      - published
 
 permissions: {}
 


### PR DESCRIPTION
#### Summary
Event to trigger workflow run is `push`, not `tags`. The `tags` part is just a filter.

But, we're copying `sigstore-python` and using `release` trigger instead of `push`. This means that in order to trigger a release we have to create a new release in the repo, whereas with `push` we would need to do `git tag`, `git push --tags`. They are equivalent in the end result, but for consistency with `sigstore-python` let's use the same approach.

#### Release Note
NONE
#### Documentation
NONE