### PR TITLE
Add support for Python 3.13.

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false # Don't cancel other jobs if one fails
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
     - name: Set up Hatch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "Topic :: Security",
@@ -62,7 +63,7 @@ parallel = true
 randomize = true
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.10", "3.11", "3.12"]
+python = ["3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.bench]
 description = """Custom environment for running benchmarks.
@@ -74,7 +75,7 @@ extra-dependencies = [
 ]
 
 [[tool.hatch.envs.bench.matrix]]
-python = ["3.10", "3.11", "3.12"]
+python = ["3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.bench.scripts]
 generate = "python benchmarks/generate.py {args}"


### PR DESCRIPTION
#### Summary

Starting from now, we will always support the last 4 versions of Python.  We'll try to support the version used in Colab, that's the one that imposes the lower bound on support.

#### Release Note
NONE

#### Documentation
NONE