### PR TITLE
add cli container provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,13 @@ jobs:
           tags: ${{ steps.build_image.outputs.tags }}
           registry: ghcr.io
 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@7668571508540a607bdfd90a87a560489fe372eb # v2.1.0
+        with:
+          subject-name: ghcr.io/sigstore/model-transparency-cli
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
   # TODO: Create and publish release notes
   # TODO: Generate SLSA provenance for the wheels
   # TODO: Sign artifacts with sigstore and publish to release page

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           containerfiles: |
             ./Containerfile
           image: ghcr.io/sigstore/model-transparency-cli
-          tags: latest
+          tags: "latest ${{ github.event.release.tag_name }}"
           archs: amd64
           oci: false
 


### PR DESCRIPTION
#### Summary
Adds provenance to the container image using GitHub's `actions/attest-build-provenance` action. This uses Sigstore Bundles under the hood. 

Part 2 of https://github.com/sigstore/model-transparency/pull/333#discussion_r1876342751.

Also adds tags the image with the corresponding release tag, not just "latest".

#### Release Note
NONE

#### Documentation
