### PR TITLE
add script to run hash algorithm benchmark

### DIFF
--- a/benchmarks/exp_hash.py
+++ b/benchmarks/exp_hash.py
@@ -52,11 +52,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-        "--data-sizes",
-        help="hash methods to benchmark",
-        nargs="+",
-        type=int,
-        default=[KB, MB, 512 * MB, GB, 4 * GB, 16 * GB, 32 * GB],
+        "--data-sizes", help="hash methods to benchmark", nargs="+", type=int
     )
 
     return parser
@@ -87,11 +83,23 @@ def _generate_data(size: int) -> bytes:
     return np.random.randint(0, 256, size, dtype=np.uint8).tobytes()
 
 
+def _default_sizes() -> list[int]:
+    """Generates sizes following 1, 2, 5 pattern, useful for log scale."""
+    sizes = []
+    for scale in [KB, MB, GB]:
+        for d in [1, 2, 5, 10, 20, 50, 100, 200, 500]:
+            if scale == GB and d > 20:
+                break
+            sizes.append(d * scale)
+    return sizes
+
+
 if __name__ == "__main__":
     np.random.seed(42)
     args = build_parser().parse_args()
-    data = _generate_data(max(args.data_sizes))
-    for size in args.data_sizes:
+    sizes = args.data_sizes or _default_sizes()
+    data = _generate_data(max(sizes))
+    for size in sizes:
         for algorithm in args.methods:
             hasher = _get_hasher(algorithm)
 

--- a/benchmarks/exp_hash.py
+++ b/benchmarks/exp_hash.py
@@ -122,4 +122,4 @@ if __name__ == "__main__":
             # Grab the min time, as suggested by the docs
             # https://docs.python.org/3/library/timeit.html#timeit.Timer.repeat
             measurement = min(times)
-            print(f"{f'{algorithm}/{size}: ':<{padding}}{measurement}")
+            print(f"{f'{algorithm}/{size}: ':<{padding}}{measurement:10.4f}")

--- a/benchmarks/exp_hash.py
+++ b/benchmarks/exp_hash.py
@@ -107,13 +107,14 @@ if __name__ == "__main__":
     args = build_parser().parse_args()
     sizes = args.data_sizes or _default_sizes()
     padding = _get_padding(args.methods, sizes)
-    data = _generate_data(max(sizes))
+
     for size in sizes:
+        data = _generate_data(size)
         for algorithm in args.methods:
             hasher = _get_hasher(algorithm)
 
-            def hash(hasher=hasher, size=size):
-                hasher.update(data[:size])
+            def hash(hasher=hasher, data=data):
+                hasher.update(data)
                 return hasher.compute()
 
             times = timeit.repeat(lambda: hash(), number=1, repeat=args.repeat)

--- a/benchmarks/exp_hash.py
+++ b/benchmarks/exp_hash.py
@@ -1,0 +1,71 @@
+# Copyright 2025 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Script for running a benchmark to pick a hashing algorithm."""
+
+import argparse
+import pathlib
+import timeit
+
+import serialize
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Builds the command line parser for the hash experiment."""
+    parser = argparse.ArgumentParser(
+        description="hash algorithm benchmark data for model signing"
+    )
+    parser.add_argument("path", help="path to model", type=pathlib.Path)
+
+    parser.add_argument(
+        "--repeat",
+        help="how many times to repeat each algorithm",
+        type=int,
+        default=5,
+    )
+
+    parser.add_argument(
+        "--methods",
+        help="hash methods to benchmark",
+        nargs="+",
+        type=str,
+        default=["sha256", "blake2"],
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    hash_args = build_parser().parse_args()
+    bench_parser = serialize.build_parser()
+    for algorithm in hash_args.methods:
+        args = bench_parser.parse_args(
+            [
+                str(hash_args.path),
+                "--skip_manifest",
+                "--hash_method",
+                algorithm,
+                "--merge_hasher",
+                algorithm,
+            ]
+        )
+        times = timeit.repeat(
+            lambda args=args: serialize.run(args),
+            number=1,
+            repeat=hash_args.repeat,
+        )
+        # Grab the min time, as suggested by the docs
+        # https://docs.python.org/3/library/timeit.html#timeit.Timer.repeat
+        print(f"algorithm: {algorithm}, best time: {min(times)}s")

--- a/benchmarks/exp_hash.py
+++ b/benchmarks/exp_hash.py
@@ -94,10 +94,19 @@ def _default_sizes() -> list[int]:
     return sizes
 
 
+def _get_padding(methods: list[str], sizes: list[int]) -> int:
+    """Calculates the necessary padding by looking at longest output.
+
+    E.g. "sha256/1024: " would require 13 characters of padding.
+    """
+    return len(f"{max(methods, key=len)}/{max(sizes)}: ")
+
+
 if __name__ == "__main__":
     np.random.seed(42)
     args = build_parser().parse_args()
     sizes = args.data_sizes or _default_sizes()
+    padding = _get_padding(args.methods, sizes)
     data = _generate_data(max(sizes))
     for size in sizes:
         for algorithm in args.methods:
@@ -111,8 +120,5 @@ if __name__ == "__main__":
 
             # Grab the min time, as suggested by the docs
             # https://docs.python.org/3/library/timeit.html#timeit.Timer.repeat
-            print(
-                f"algorithm: {algorithm}, "
-                f"size: {_human_size(size)}, "
-                f"best time: {min(times)}s"
-            )
+            measurement = min(times)
+            print(f"{f'{algorithm}/{size}: ':<{padding}}{measurement}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ python = ["3.10", "3.11", "3.12", "3.13"]
 [tool.hatch.envs.bench.scripts]
 generate = "python benchmarks/generate.py {args}"
 serialize = "python benchmarks/serialize.py {args}"
+hash = "python benchmarks/exp_hash.py {args}"
 
 [tool.hatch.envs.docs]
 description = """Custom environment for pdoc.


### PR DESCRIPTION
#### Summary
Builds upon the work in #306 and starts to define individual experiments. This one is aimed specifically at hashing algorithm.

As far as hashing is concerned, bytes are bytes. By generating our own bytes, we avoid I/O associated with reading models from disk. While we could read actual models into memory, recreating the filesystem seems unecessary for this benchmark.

```shell
$ hatch run +py=3.11 bench:hash --repeat 5 --methods sha256 blake2
algorithm: sha256, size: 1.0 KB, best time: 2.569984644651413e-06s
algorithm: blake2, size: 1.0 KB, best time: 3.1301751732826233e-06s
algorithm: sha256, size: 1.0 MB, best time: 0.0007016910240054131s
algorithm: blake2, size: 1.0 MB, best time: 0.001357788685709238s
algorithm: sha256, size: 512.0 MB, best time: 0.41755866911262274s
algorithm: blake2, size: 512.0 MB, best time: 0.7319729649461806s
algorithm: sha256, size: 1.0 GB, best time: 0.8285107491537929s
algorithm: blake2, size: 1.0 GB, best time: 1.466184071265161s
algorithm: sha256, size: 4.0 GB, best time: 3.375688728876412s
algorithm: blake2, size: 4.0 GB, best time: 5.8439111188054085s
algorithm: sha256, size: 16.0 GB, best time: 14.146526537369937s
algorithm: blake2, size: 16.0 GB, best time: 23.482591222040355s
algorithm: sha256, size: 32.0 GB, best time: 21.890016920864582s
algorithm: blake2, size: 32.0 GB, best time: 42.17644724994898s
```

#### Release Note
NONE

#### Documentation
NONE
