### PR TITLE
Add support for Python 3.9

### DIFF
--- a/benchmarks/exp_hash.py
+++ b/benchmarks/exp_hash.py
@@ -69,11 +69,12 @@ def _human_size(size: int) -> str:
 
 
 def _get_hasher(hash_algorithm: str) -> hashing.StreamingHashEngine:
-    match hash_algorithm:
-        case "sha256":
-            return memory.SHA256()
-        case "blake2":
-            return memory.BLAKE2()
+    # TODO: Once Python 3.9 support is deprecated revert to using `match`
+    if hash_algorithm == "sha256":
+        return memory.SHA256()
+    if hash_algorithm == "blake2":
+        return memory.BLAKE2()
+
     raise ValueError(f"Cannot convert {hash_algorithm} to a hash engine")
 
 

--- a/benchmarks/generate.py
+++ b/benchmarks/generate.py
@@ -17,6 +17,7 @@
 import argparse
 import itertools
 import pathlib
+from typing import Optional
 
 import numpy as np
 
@@ -45,7 +46,7 @@ def create_file_of_given_size(path: str, size: int) -> None:
 
 
 def generate_file_sizes(
-    total_size: int, count: int, weights: list[int] | None = None
+    total_size: int, count: int, weights: Optional[list[int]] = None
 ) -> list[int]:
     """Generate file sizes splitting a total size into multiple files.
 

--- a/benchmarks/serialize.py
+++ b/benchmarks/serialize.py
@@ -40,11 +40,11 @@ def get_hash_engine_factory(
     Raises:
         ValueError: if the algorithm is not implemented/not valid.
     """
-    match hash_algorithm:
-        case "sha256":
-            return memory.SHA256
-        case "blake2":
-            return memory.BLAKE2
+    # TODO: Once Python 3.9 support is deprecated revert to using `match`
+    if hash_algorithm == "sha256":
+        return memory.SHA256
+    if hash_algorithm == "blake2":
+        return memory.BLAKE2
 
     raise ValueError(f"Cannot convert {hash_algorithm} to a hash engine")
 
@@ -152,14 +152,16 @@ def run(args: argparse.Namespace) -> None:
         if args.single_digest:
             in_toto_builder = in_toto.SingleDigestIntotoPayload
         else:
-            match (args.digest_of_digests, args.use_shards):
-                case (True, True):
+            # TODO: Once Python 3.9 support is deprecated revert to `match`
+            if args.digest_of_digests:
+                if args.use_shards:
                     in_toto_builder = in_toto.DigestOfShardDigestsIntotoPayload
-                case (True, False):
+                else:
                     in_toto_builder = in_toto.DigestOfDigestsIntotoPayload
-                case (False, True):
+            else:
+                if args.use_shards:
                     in_toto_builder = in_toto.ShardDigestsIntotoPayload
-                case (False, False):
+                else:
                     in_toto_builder = in_toto.DigestsIntotoPayload
 
         in_toto_builder = in_toto_builder.from_manifest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -32,7 +33,7 @@ dependencies = [
   "sigstore",
   "typing_extensions",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 keywords = [
   "machine learning",
   "artificial intelligence",
@@ -64,7 +65,7 @@ randomize = true
 extra-args = ["-m", "not integration"]
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.10", "3.11", "3.12", "3.13"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.bench]
 description = """Custom environment for running benchmarks.
@@ -76,7 +77,7 @@ extra-dependencies = [
 ]
 
 [[tool.hatch.envs.bench.matrix]]
-python = ["3.10", "3.11", "3.12", "3.13"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.bench.scripts]
 generate = "python benchmarks/generate.py {args}"

--- a/src/model_signing/api.py
+++ b/src/model_signing/api.py
@@ -149,15 +149,13 @@ class HashingConfig:
         Returns:
             An instance of the requested hasher.
         """
-        match hashing_algorithm:
-            case "sha256":
-                return memory.SHA256()
-            case "blake2":
-                return memory.BLAKE2()
-            case _:
-                raise ValueError(
-                    f"Unsupported hashing method {hashing_algorithm}"
-                )
+        # TODO: Once Python 3.9 support is deprecated revert to using `match`
+        if hashing_algorithm == "sha256":
+            return memory.SHA256()
+        if hashing_algorithm == "blake2":
+            return memory.BLAKE2()
+
+        raise ValueError(f"Unsupported hashing method {hashing_algorithm}")
 
     def _build_file_hasher_factory(
         self,

--- a/src/model_signing/api.py
+++ b/src/model_signing/api.py
@@ -23,7 +23,7 @@ from collections.abc import Callable, Iterable
 import os
 import pathlib
 import sys
-from typing import Literal, cast
+from typing import Literal, Optional, cast
 
 from model_signing.hashing import file
 from model_signing.hashing import hashing
@@ -78,7 +78,7 @@ def verify(
     signature_path: os.PathLike,
     *,
     identity: str,
-    oidc_issuer: str | None = None,
+    oidc_issuer: Optional[str] = None,
     use_staging: bool = False,
 ):
     """Verifies that a model conforms to a signature.
@@ -223,7 +223,7 @@ class HashingConfig:
         *,
         hashing_algorithm: Literal["sha256", "blake2"] = "sha256",
         chunk_size: int = 8192,
-        max_workers: int | None = None,
+        max_workers: Optional[int] = None,
         allow_symlinks: bool = False,
     ) -> Self:
         """Configures serialization to a manifest pairing files with hashes.
@@ -302,7 +302,7 @@ class HashingConfig:
         hashing_algorithm: Literal["sha256", "blake2"] = "sha256",
         chunk_size: int = 8192,
         shard_size: int = 1000000,
-        max_workers: int | None = None,
+        max_workers: Optional[int] = None,
         allow_symlinks: bool = False,
     ) -> Self:
         """Configures serialization to a manifest of (file shard, hash) pairs.
@@ -343,7 +343,7 @@ class HashingConfig:
         merge_algorithm: Literal["sha256", "blake2"] = "sha256",
         chunk_size: int = 8192,
         shard_size: int = 1000000,
-        max_workers: int | None = None,
+        max_workers: Optional[int] = None,
         allow_symlinks: bool = False,
     ) -> Self:
         """Configures serialization to a single digest, at shard granularity.
@@ -467,10 +467,10 @@ class SigningConfig:
         self,
         *,
         sign_dsse: bool = True,
-        oidc_issuer: str | None = None,
+        oidc_issuer: Optional[str] = None,
         use_ambient_credentials: bool = True,
         use_staging: bool = False,
-        identity_token: str | None = None,
+        identity_token: Optional[str] = None,
     ) -> Self:
         """Configures the signing to be performed with Sigstore.
 
@@ -556,7 +556,7 @@ class VerificationConfig:
         self,
         *,
         identity: str,
-        oidc_issuer: str | None = None,
+        oidc_issuer: Optional[str] = None,
         use_staging: bool = False,
     ) -> Self:
         """Configures the verification of a Sigstore signature over DSSE.

--- a/src/model_signing/hashing/file.py
+++ b/src/model_signing/hashing/file.py
@@ -49,7 +49,7 @@ Example usage for `OpenedFileHasher`:
 import hashlib
 import pathlib
 import sys
-from typing import BinaryIO
+from typing import BinaryIO, Optional
 
 from typing_extensions import override
 
@@ -84,7 +84,7 @@ class SimpleFileHasher(FileHasher):
         content_hasher: hashing.StreamingHashEngine,
         *,
         chunk_size: int = 8192,
-        digest_name_override: str | None = None,
+        digest_name_override: Optional[str] = None,
     ):
         """Initializes an instance to hash a file with a specific `HashEngine`.
 
@@ -161,7 +161,7 @@ class OpenedFileHasher(FileHasher):
         file_descriptor: BinaryIO,
         *,
         algorithm: str = "sha256",
-        digest_name_override: str | None = None,
+        digest_name_override: Optional[str] = None,
     ):
         """Initializes an instance to hash a file with a specific algorithm.
 
@@ -237,7 +237,7 @@ class ShardedFileHasher(SimpleFileHasher):
         end: int,
         chunk_size: int = 8192,
         shard_size: int = 1000000,
-        digest_name_override: str | None = None,
+        digest_name_override: Optional[str] = None,
     ):
         """Initializes an instance to hash a file with a specific `HashEngine`.
 

--- a/src/model_signing/serialization/serialize_by_file.py
+++ b/src/model_signing/serialization/serialize_by_file.py
@@ -20,7 +20,7 @@ from collections.abc import Callable, Iterable
 import concurrent.futures
 import itertools
 import pathlib
-from typing import cast
+from typing import Optional, cast
 
 from typing_extensions import override
 
@@ -110,7 +110,7 @@ class FilesSerializer(serialization.Serializer):
         self,
         file_hasher_factory: Callable[[pathlib.Path], file.FileHasher],
         *,
-        max_workers: int | None = None,
+        max_workers: Optional[int] = None,
         allow_symlinks: bool = False,
     ):
         """Initializes an instance to serialize a model with this serializer.
@@ -252,7 +252,7 @@ class _FileDigestTree:
     """
 
     def __init__(
-        self, path: pathlib.PurePath, digest: hashing.Digest | None = None
+        self, path: pathlib.PurePath, digest: Optional[hashing.Digest] = None
     ):
         """Builds a node in the digest tree.
 

--- a/src/model_signing/serialization/serialize_by_file_shard.py
+++ b/src/model_signing/serialization/serialize_by_file_shard.py
@@ -20,7 +20,7 @@ from collections.abc import Callable, Iterable
 import concurrent.futures
 import itertools
 import pathlib
-from typing import cast
+from typing import Optional, cast
 
 from typing_extensions import override
 
@@ -90,7 +90,7 @@ class ShardedFilesSerializer(serialization.Serializer):
             [pathlib.Path, int, int], file.ShardedFileHasher
         ],
         *,
-        max_workers: int | None = None,
+        max_workers: Optional[int] = None,
         allow_symlinks: bool = False,
     ):
         """Initializes an instance to serialize a model with this serializer.
@@ -269,7 +269,7 @@ class DigestSerializer(ShardedFilesSerializer):
         ],
         merge_hasher: hashing.StreamingHashEngine,
         *,
-        max_workers: int | None = None,
+        max_workers: Optional[int] = None,
         allow_symlinks: bool = False,
     ):
         """Initializes an instance to serialize a model with this serializer.

--- a/src/model_signing/signature/key.py
+++ b/src/model_signing/signature/key.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Functionality to sign and verify models with keys."""
 
+from typing import Optional
+
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.hashes import SHA256
@@ -30,7 +32,7 @@ from model_signing.signature.verifying import Verifier
 
 
 def load_ec_private_key(
-    path: str, password: str | None = None
+    path: str, password: Optional[str] = None
 ) -> ec.EllipticCurvePrivateKey:
     private_key: ec.EllipticCurvePrivateKey
     with open(path, "rb") as fd:
@@ -48,7 +50,7 @@ class ECKeySigner(Signer):
         self._private_key = private_key
 
     @classmethod
-    def from_path(cls, private_key_path: str, password: str | None = None):
+    def from_path(cls, private_key_path: str, password: Optional[str] = None):
         private_key = load_ec_private_key(private_key_path, password)
         return cls(private_key)
 

--- a/src/model_signing/signature/pki.py
+++ b/src/model_signing/signature/pki.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Functionality to sign and verify models with certificates."""
 
-from typing import Self
+from typing import Optional, Self
 
 import certifi
 from cryptography import x509
@@ -120,14 +120,14 @@ class PKIVerifier(Verifier):
     """Provides a verifier based on root certificates."""
 
     def __init__(
-        self, root_certs: list[x509.Certificate] | None = None
+        self, root_certs: Optional[list[x509.Certificate]] = None
     ) -> None:
         self._store = ssl_crypto.X509Store()
         for c in root_certs:
             self._store.add_cert(ssl_crypto.X509.from_cryptography(c))
 
     @classmethod
-    def from_paths(cls, root_cert_paths: list[str] | None = None) -> Self:
+    def from_paths(cls, root_cert_paths: Optional[list[str]] = None) -> Self:
         crypto_trust_roots: list[x509.Certificate] = []
         if root_cert_paths:
             crypto_trust_roots = _load_multiple_certs(root_cert_paths)

--- a/src/model_signing/signing/sign_sigstore.py
+++ b/src/model_signing/signing/sign_sigstore.py
@@ -17,6 +17,7 @@
 import json
 import pathlib
 import sys
+from typing import Optional
 
 from google.protobuf import json_format
 from sigstore import dsse as sigstore_dsse
@@ -99,10 +100,10 @@ class SigstoreSigner(signing.Signer):
     def __init__(
         self,
         *,
-        oidc_issuer: str | None = None,
+        oidc_issuer: Optional[str] = None,
         use_ambient_credentials: bool = True,
         use_staging: bool = False,
-        identity_token: str | None = None,
+        identity_token: Optional[str] = None,
     ):
         """Initializes Sigstore signers.
 


### PR DESCRIPTION
#### Summary
Add support for Python3.9 to match integration requests.

Luckily, this was not much to do. Just change `T | None` into `Optional[T]` and replace `match` statements with `if`.

#### Release Note
Python 3.9 is also supported.

#### Documentation
NONE
