### PR TITLE
add chunk size experiment

### DIFF
--- a/benchmarks/exp_chunk.py
+++ b/benchmarks/exp_chunk.py
@@ -1,0 +1,68 @@
+# Copyright 2025 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Script for running a benchmark to pick a chunk parameter."""
+
+import argparse
+import timeit
+
+import serialize
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Builds the command line parser for the chunk experiment."""
+    parser = argparse.ArgumentParser(
+        description="chunk size benchmark data for model signing"
+    )
+
+    parser.add_argument("path", help="path to model")
+
+    parser.add_argument(
+        "--repeat",
+        help="how many times to repeat each chunk size",
+        type=int,
+        default=5,
+    )
+
+    parser.add_argument(
+        "--sizes", help="chunk sizes to benchmark", nargs="+", type=int
+    )
+
+    return parser
+
+
+def _default_sizes() -> list[int]:
+    # 0 is a special value to (attempt to) read whole files into RAM
+    # then powers of 2 between 1KB and 1GB
+    return (
+        [0] + [2**i for i in range(10, 31)]
+    )  # pytype: disable=bad-return-type (https://github.com/google/pytype/issues/795)
+
+
+if __name__ == "__main__":
+    chunk_args = build_parser().parse_args()
+
+    chunk_sizes = chunk_args.sizes or _default_sizes()
+    padding = len(f"{max(chunk_sizes)}: ")
+    for chunk_size in chunk_sizes:
+        args = serialize.build_parser().parse_args(
+            [chunk_args.path, f"--chunk={chunk_size}"]
+        )
+        times = timeit.repeat(
+            lambda args=args: serialize.run(args),
+            number=1,
+            repeat=chunk_args.repeat,
+        )
+        print(f"{f'{chunk_size}: ':<{padding}}{min(times):10.4f}")

--- a/benchmarks/exp_chunk.py
+++ b/benchmarks/exp_chunk.py
@@ -46,9 +46,11 @@ def build_parser() -> argparse.ArgumentParser:
 def _default_sizes() -> list[int]:
     # 0 is a special value to (attempt to) read whole files into RAM
     # then powers of 2 between 1KB and 1GB
-    return (
-        [0] + [2**i for i in range(10, 31)]
-    )  # pytype: disable=bad-return-type (https://github.com/google/pytype/issues/795)
+
+    # https://github.com/google/pytype/issues/795
+    # pytype: disable=bad-return-type
+    return [0] + [2**i for i in range(10, 31)]
+    # pytype: enable=bad-return-type
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 description = """Custom environment for running benchmarks.
 Use `hatch run +py=3... bench:generate ${args}` to generate test models.
 Use `hatch run +py=3... bench:serialize ${args}` to benchmark serialization code.
+Use `hatch run +py=3... bench:hash ${args}` to benchmark hashing code.
+Use `hatch run +py=3... bench:chunk ${args}` to benchmark the chunk size parameter.
 """
 extra-dependencies = [
   "numpy",
@@ -83,6 +85,7 @@ python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 generate = "python benchmarks/generate.py {args}"
 serialize = "python benchmarks/serialize.py {args}"
 hash = "python benchmarks/exp_hash.py {args}"
+chunk = "python benchmarks/exp_chunk.py {args}"
 
 [tool.hatch.envs.docs]
 description = """Custom environment for pdoc.


### PR DESCRIPTION
#### Summary
Adds a simple experiment to vary chunk size, built on top of #306

So far, the experiment has shown similar results on two different machines (ARM64 macOS and x86 Linux), and on two different models. (Currently running with the default repeat of 5, which takes longer)

Two factors may limit what models can be benchmarked:
1. Special size of 0, which will attempt to read whole files into memory.
2. `timeit.timeit` disables garbage collection, so even if smaller buffers are used, older ones may stay around in memory.

The hashing algorithm was left as SHA256 based on the results from the hashing experiment.

```shell
hatch run +py=3.11 bench:chunk /tmp/falcon-7b --repeat 1
0:             14.6712
1024:          75.8065
2048:         126.7567
4096:         111.4476
8192:          97.4376
16384:         47.9187
32768:         19.5353
65536:         11.5445
131072:         7.8582
262144:         7.6625
524288:         7.5540
1048576:        7.4961
2097152:        7.5713
4194304:        7.6006
8388608:        7.7660
16777216:       7.8013
33554432:       8.5476
67108864:       8.5441
134217728:      8.5804
268435456:      8.6592
536870912:      8.8148
1073741824:     9.2775
```

The result of the benchmarks suggest increasing the chunk size to at least 128 KB (131072) with a 1MB read size producing the best results in this benchmark. Happy to do that in a follow-up PR, or this one.

#### Release Note
NONE

#### Documentation
NONE
