### PR TITLE
small bugfix do not indicate wrong results

### DIFF
--- a/src/verify.py
+++ b/src/verify.py
@@ -17,6 +17,7 @@
 import argparse
 import logging
 import pathlib
+import sys
 
 from model_signing import model
 from model_signing.hashing import file
@@ -168,7 +169,7 @@ def main():
         )
     except verifying.VerificationError as err:
         log.error(f"verification failed: {err}")
-        exit(-1)
+        sys.exit(-1)
 
     log.info("all checks passed")
 

--- a/src/verify.py
+++ b/src/verify.py
@@ -168,6 +168,7 @@ def main():
         )
     except verifying.VerificationError as err:
         log.error(f"verification failed: {err}")
+        exit(-1)
 
     log.info("all checks passed")
 


### PR DESCRIPTION
#### Summary
Fixing a small bug where in a case of a verification failure the last output was still `all checks passed`.
