### PR TITLE
fix: ensure verify terminates on model validation failure

### DIFF
--- a/src/sign.py
+++ b/src/sign.py
@@ -17,6 +17,7 @@
 import argparse
 import logging
 import pathlib
+import sys
 
 from model_signing import model
 from model_signing.hashing import file
@@ -148,13 +149,13 @@ def _get_payload_signer(args: argparse.Namespace) -> signing.Signer:
         log.error(
             'supported methods: ["pki", "private-key", "sigstore", "skip"]'
         )
-        exit(-1)
+        sys.exit(1)
 
 
 def _check_private_key_options(args: argparse.Namespace):
     if args.key_path == "":
         log.error("--private_key must be set to a valid private key PEM file")
-        exit()
+        sys.exit()
 
 
 def _check_pki_options(args: argparse.Namespace):
@@ -166,7 +167,7 @@ def _check_pki_options(args: argparse.Namespace):
                 "PEM encoded signing certificate",
             )
         )
-        exit()
+        sys.exit()
     if args.cert_chain_path == "":
         log.warning("No certificate chain provided")
 

--- a/src/sign.py
+++ b/src/sign.py
@@ -167,7 +167,7 @@ def _check_pki_options(args: argparse.Namespace):
                 "PEM encoded signing certificate",
             )
         )
-        sys.exit()
+        sys.exit(1)
     if args.cert_chain_path == "":
         log.warning("No certificate chain provided")
 

--- a/src/sign.py
+++ b/src/sign.py
@@ -155,7 +155,7 @@ def _get_payload_signer(args: argparse.Namespace) -> signing.Signer:
 def _check_private_key_options(args: argparse.Namespace):
     if args.key_path == "":
         log.error("--private_key must be set to a valid private key PEM file")
-        sys.exit()
+        sys.exit(1)
 
 
 def _check_pki_options(args: argparse.Namespace):

--- a/src/verify.py
+++ b/src/verify.py
@@ -16,8 +16,8 @@
 
 import argparse
 import logging
-import os
 import pathlib
+import sys
 
 from model_signing import model
 from model_signing.hashing import file
@@ -119,13 +119,13 @@ def _get_verifier(args: argparse.Namespace) -> signing.Verifier:
         log.error(
             'supported methods: ["pki", "private-key", "sigstore", "skip"]'
         )
-        exit(-1)
+        sys.exit(1)
 
 
 def _check_private_key_flags(args: argparse.Namespace):
     if args.key == "":
         log.error("--public_key must be defined")
-        exit()
+        sys.exit()
 
 
 def _check_pki_flags(args: argparse.Namespace):
@@ -169,7 +169,7 @@ def main():
         )
     except verifying.VerificationError as err:
         log.error(f"verification failed: {err}")
-        os._exit(-1)
+        sys.exit(1)
 
     log.info("all checks passed")
 

--- a/src/verify.py
+++ b/src/verify.py
@@ -16,8 +16,8 @@
 
 import argparse
 import logging
+import os
 import pathlib
-import sys
 
 from model_signing import model
 from model_signing.hashing import file
@@ -169,7 +169,7 @@ def main():
         )
     except verifying.VerificationError as err:
         log.error(f"verification failed: {err}")
-        sys.exit(-1)
+        os._exit(-1)
 
     log.info("all checks passed")
 

--- a/src/verify.py
+++ b/src/verify.py
@@ -125,7 +125,7 @@ def _get_verifier(args: argparse.Namespace) -> signing.Verifier:
 def _check_private_key_flags(args: argparse.Namespace):
     if args.key == "":
         log.error("--public_key must be defined")
-        sys.exit()
+        sys.exit(1)
 
 
 def _check_pki_flags(args: argparse.Namespace):


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Ensure verify terminates on model validation failure.

Closes #351 

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note

fix: ensure verify terminates on model validation failure
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
---

Now it seems to work as expected :)

```
Init Containers:
  model-validation:
    Container ID:  containerd://6b4dfaa5cb32191638bb57fa77a7dc1ff0f4541ea65ebac047556e0bea636bad
    Image:         ghcr.io/miyunari/model-transparency-cli:latest
    Image ID:      ghcr.io/miyunari/model-transparency-cli@sha256:57e80c133028dbc28d1be265756dc8e2382a0891b6c6a4662854623f70c30ff2
    Command:
      verify
      --model_path=/data
      --sig_path=/data/model.sig
      sigstore
      --identity
      https://github.com/miyunari/model-validation-controller/.github/workflows/sign-model.yaml@refs/tags/v0.0.2
      --identity-provider
      https://token.actions.githubusercontent.com
    State:          Terminated           <<-------------------------------
      Reason:       Error
      Exit Code:    255
      Started:      Mon, 27 Jan 2025 11:46:59 +0100
      Finished:     Mon, 27 Jan 2025 11:47:00 +0100
```