### PR TITLE
add shard benchmark experiment

### DIFF
--- a/benchmarks/exp_shard.py
+++ b/benchmarks/exp_shard.py
@@ -1,0 +1,91 @@
+# Copyright 2025 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Script for running a benchmark to pick a shard parameter."""
+
+import argparse
+import time
+from typing import Final
+
+from google.protobuf import json_format
+import serialize
+
+from model_signing.signing import in_toto
+
+
+KB: Final[int] = 1024
+MB: Final[int] = 1024 * KB
+GB: Final[int] = 1024 * MB
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Builds the command line parser for the shard experiment."""
+    parser = argparse.ArgumentParser(
+        description="shard size benchmark data for model signing"
+    )
+
+    parser.add_argument("path", help="path to model")
+
+    parser.add_argument(
+        "--repeat",
+        help="how many times to repeat each shard size",
+        type=int,
+        default=5,
+    )
+
+    parser.add_argument(
+        "--sizes", help="shard sizes to benchmark", nargs="+", type=int
+    )
+
+    return parser
+
+
+def _default_sizes() -> list[int]:
+    sizes = []
+    for scale in [MB, GB]:
+        for d in [1, 2, 5, 10, 20, 50, 100, 200, 500]:
+            if d * scale > 10 * GB:
+                break
+            sizes.append(d * scale)
+    return sizes
+
+
+if __name__ == "__main__":
+    shard_args = build_parser().parse_args()
+
+    shard_sizes = shard_args.sizes or _default_sizes()
+    padding = len(f"{max(shard_sizes)}: ")
+    for shard in shard_sizes:
+        times = []
+        manifest_size = None
+        for _ in range(shard_args.repeat):
+            args = serialize.build_parser().parse_args(
+                [shard_args.path, "--use_shards", f"--shard={shard}"]
+            )
+            st = time.time()
+            payload = serialize.run(args)
+            en = time.time()
+            times.append(en - st)
+
+            if not isinstance(payload, in_toto.IntotoPayload):
+                raise TypeError("IntotoPayloads expected")
+
+            if not manifest_size:
+                statement = json_format.MessageToJson(
+                    payload.statement.pb
+                ).encode("utf-8")
+                manifest_size = len(statement)
+
+        print(f"{f'{shard}: ':<{padding}}{min(times):10.4f} {manifest_size:8}")


### PR DESCRIPTION
#### Summary
The current default is 1MB, though previous benchmarks used GB in the past, so vary the shard size roughly in that range. Each benchmark is concerned with hash time, as well as manifest time.

In previous experimentation, the shard size does depend a bit on the model being analyzed, I picked two models, but it may be good to check with models that shard differently.

preliminary data says 2GiB is a good shard size
```
python3 benchmarks/exp_shard.py ~/models/falcon-7b
1048576:         9.9655  7787170
2097152:         5.8016  3895373
5242880:         3.3394  1560636
10485760:        2.5500   784869
20971520:        2.1676   393941
52428800:        1.9733   159605
104857600:       1.9009    81596
209715200:       1.8476    42876
524288000:       1.8293    18960
1073741824:      1.8951    11599
2147483648:      1.6447     7595
5368709120:      3.9575     4735
10737418240:     7.2927     4178
```

```
python3 benchmarks/exp_shard.py ~/models/gemma-7b/
1048576:        23.5757 13253524
2097152:        10.8698  6628968
5242880:         6.0967  2653668
10485760:        4.6714  1333666
20971520:        3.9581   668485
52428800:        3.6173   270200
104857600:       3.4757   137385
209715200:       3.3168    70477
524288000:       3.3041    30887
1073741824:      2.9686    16736
2147483648:      2.6510    10440
5368709120:      4.4327     6309
10737418240:     8.5381     5524
```

#### Release Note
NONE

#### Documentation
NONE
