### PR TITLE
arg parsing bugfix

### DIFF
--- a/src/sign.py
+++ b/src/sign.py
@@ -65,7 +65,7 @@ def _arguments() -> argparse.Namespace:
         help="paths to pem encoded certificate files or a single file"
         + "containing a chain",
         required=False,
-        type=list[str],
+        type=str,
         default=[],
         nargs="+",
         dest="cert_chain_path",

--- a/src/verify.py
+++ b/src/verify.py
@@ -63,7 +63,8 @@ def _arguments() -> argparse.Namespace:
         help="paths to PEM encoded certificate files or a single file"
         + "used as the root of trust",
         required=False,
-        type=list[str],
+        nargs="+",
+        type=str,
         default=[],
         dest="root_certs",
     )


### PR DESCRIPTION
The argument parsing for string lists was wrong. This PR fixes the issues by setting nargs and the type correctly.

closes #361