### PR TITLE
[cleanup] Remove obsolete TODO

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "cryptography",  # TODO: make pki a feature
+  "cryptography",
   "in-toto-attestation",
   "sigstore",
   "typing_extensions",


### PR DESCRIPTION
#### Summary
Initially was planning to use non-sigstore signing as an optional feature, but that does not make sense. However, we forgot to remove this TODO.

#### Release Note
NONE

#### Documentation
NONE
