### PR TITLE
Make default Python version be 3.12

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false # Don't cancel other jobs if one fails
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     permissions:
       contents: read
     steps:

--- a/.github/workflows/slsa_for_ml.yml
+++ b/.github/workflows/slsa_for_ml.yml
@@ -68,7 +68,7 @@ jobs:
         persist-credentials: false
     - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
-        python-version: 3.13
+        python-version: 3.11
         cache: pip
         cache-dependency-path: slsa_for_models/install/requirements_${{ matrix.os_family }}.txt
     - name: Install dependencies

--- a/.github/workflows/slsa_for_ml.yml
+++ b/.github/workflows/slsa_for_ml.yml
@@ -68,7 +68,7 @@ jobs:
         persist-credentials: false
     - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
-        python-version: 3.11
+        python-version: 3.13
         cache: pip
         cache-dependency-path: slsa_for_models/install/requirements_${{ matrix.os_family }}.txt
     - name: Install dependencies

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -47,14 +47,14 @@ jobs:
     - name: Run unit tests (with coverage report at the end)
       run: |
         set -euxo pipefail
-        if [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.python-version }}" == "3.13" ]]; then
+        if [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.python-version }}" == "3.12" ]]; then
           hatch test -c -py ${{ matrix.python-version }} | tee > cov.txt
         else
           hatch test -c -py ${{ matrix.python-version }}
         fi
 
     - name: Highlight missing lines
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
       run: |
         set -euxo pipefail
         awk '/Name/{flag=1; next} /TOTAL/{flag=0; next} flag && !/^[-]+$/' cov.txt | while IFS= read -r line; do

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Run unit tests (with coverage report at the end)
       run: |
         set -euxo pipefail
-        if [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.python-version }}" == "3.11" ]]; then
+        if [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.python-version }}" == "3.13" ]]; then
           hatch test -c -py ${{ matrix.python-version }} | tee > cov.txt
         else
           hatch test -c -py ${{ matrix.python-version }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false # Don't cancel other jobs if one fails
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     permissions:
       contents: read
     steps:
@@ -54,7 +54,7 @@ jobs:
         fi
 
     - name: Highlight missing lines
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
       run: |
         set -euxo pipefail
         awk '/Name/{flag=1; next} /TOTAL/{flag=0; next} flag && !/^[-]+$/' cov.txt | while IFS= read -r line; do

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ extra-dependencies = [
   "pytype",
 ]
 installer = "pip"
-python = "3.13"
+python = "3.12"
 
 [tool.hatch.envs.type.scripts]
 check = "pytype -k -j auto src tests benchmarks"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ extra-dependencies = [
   "pytype",
 ]
 installer = "pip"
-python = "3.11"
+python = "3.13"
 
 [tool.hatch.envs.type.scripts]
 check = "pytype -k -j auto src tests benchmarks"


### PR DESCRIPTION
#### Summary
I wanted to do 3.13 as that is the only one in "bugfix" state on https://devguide.python.org/versions/. But [typechecking does not yet work on 3.13](https://github.com/sigstore/model-transparency/actions/runs/14134975132/job/39604403109?pr=378) so we'd need to bump to only 3.12

Once Keras/Colab/Kaggle can move away from 3.9, we can also remove 3.9.

For SLSA for ML part, I left it at 3.11 since pushing forward would require more changes (we would need to update several packages anyway). Since that's not a blocker for the release, it can be ignored

#### Release Note
NONE

#### Documentation
NONE