### PR TITLE
Add a binary script for the CLI.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ keywords = [
   "ML supply chain security",
 ]
 
+[project.scripts]
+model_signing = "model_signing._cli:main"
+
 [project.urls]
 Homepage = "https://pypi.org/project/model-signing/"
 Changelog = "https://github.com/sigstore/model-transparency/blob/main/CHANGELOG.md"


### PR DESCRIPTION
#### Summary

This is a convenience binary, so instead of `python -m model_signing ${args}` people can also do `model_signing ${args}`.

#### Release Note
NONE

#### Documentation
NONE