### PR TITLE
Split the public API into three modules.

### DIFF
--- a/src/model_signing/__init__.py
+++ b/src/model_signing/__init__.py
@@ -14,4 +14,12 @@
 
 """For the stable high-level API, see model_signing.api."""
 
+from model_signing import hash
+from model_signing import sign
+from model_signing import verify
+
+
 __version__ = "0.2.0"
+
+
+__all__ = ["hash", "sign", "verify"]

--- a/src/model_signing/sign.py
+++ b/src/model_signing/sign.py
@@ -1,0 +1,148 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""High level API for the signing interface of model_signing library.
+
+Users should use this API to sign models, rather than using the internals of the
+library. We guarantee backwards compatibility only for the API defined in
+`hash.py`, `sign.py` and `verify.py` at the root level of the library.
+"""
+
+from collections.abc import Callable
+import os
+import pathlib
+import sys
+from typing import Optional
+
+from model_signing import hash
+from model_signing.manifest import manifest
+from model_signing.signing import in_toto
+from model_signing.signing import sign_sigstore as sigstore
+from model_signing.signing import signing
+
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+
+def sign(model_path: os.PathLike, signature_path: os.PathLike):
+    """Signs a model using the default configuration.
+
+    Args:
+        model_path: the path to the model to sign.
+        signature_path: the path of the resulting signature.
+    """
+    SigningConfig().sign(model_path, signature_path)
+
+
+class SigningConfig:
+    """Configuration to use when signing models.
+
+    The signing configuration is used to decouple between serialization formats
+    and signing types. This configuration class allows setting up the
+    serialization format, the method to convert a `manifest.Manifest` to a
+    signing payload and the engine used for signing (currently, only supporting
+    Sigstore at this level).
+    """
+
+    def __init__(self):
+        """Initializes the default configuration for signing."""
+        self._hashing_config = hash.HashingConfig()
+        self._payload_generator = in_toto.DigestsIntotoPayload.from_manifest
+        self._signer = sigstore.SigstoreDSSESigner(
+            use_ambient_credentials=False, use_staging=False
+        )
+
+    def sign(self, model_path: os.PathLike, signature_path: os.PathLike):
+        """Signs a model using the current configuration.
+
+        Args:
+            model_path: the path to the model to sign.
+            signature_path: the path of the resulting signature.
+        """
+        manifest = self._hashing_config.hash(model_path)
+        payload = self._payload_generator(manifest)
+        signature = self._signer.sign(payload)
+        signature.write(pathlib.Path(signature_path))
+
+    def set_hashing_config(self, hashing_config: hash.HashingConfig) -> Self:
+        """Sets the new configuration for hashing models.
+
+        Args:
+            hashing_config: the new hashing configuration.
+
+        Returns:
+            The new signing configuration.
+        """
+        self._hashing_config = hashing_config
+        return self
+
+    def set_payload_generator(
+        self, generator: Callable[[manifest.Manifest], signing.SigningPayload]
+    ) -> Self:
+        """Sets the conversion from manifest to signing payload.
+
+        Since we want to support multiple serialization formats and multiple
+        signing solutions, we use a payload generator to relax the coupling
+        between the two.
+
+        Args:
+            generator: the conversion function from a `manifest.Manifest` to a
+              `signing.SigningPayload` payload.
+
+        Return:
+            The new signing configuration.
+        """
+        self._payload_generator = generator
+        return self
+
+    def set_sigstore_signer(
+        self,
+        *,
+        oidc_issuer: Optional[str] = None,
+        use_ambient_credentials: bool = True,
+        use_staging: bool = False,
+        identity_token: Optional[str] = None,
+    ) -> Self:
+        """Configures the signing to be performed with Sigstore.
+
+        Only one signer can be configured. Currently, we only support Sigstore
+        in the API, but the CLI supports signing with PKI, BYOK and no signing.
+        We will merge the configurations in a subsequent change.
+
+        Args:
+            oidc_issuer: An optional OpenID Connect issuer to use instead of the
+              default production one. Only relevant if `use_staging = False`.
+              Default is empty, relying on the Sigstore configuration.
+            use_ambient_credentials: Use ambient credentials (also known as
+              Workload Identity). Default is True. If ambient credentials cannot
+              be used (not available, or option disabled), a flow to get signer
+              identity via OIDC will start.
+            use_staging: Use staging configurations, instead of production. This
+              is supposed to be set to True only when testing. Default is False.
+            identity_token: An explicit identity token to use when signing,
+              taking precedence over any ambient credential or OAuth workflow.
+
+        Return:
+            The new signing configuration.
+        """
+        self._signer = sigstore.SigstoreDSSESigner(
+            oidc_issuer=oidc_issuer,
+            use_ambient_credentials=use_ambient_credentials,
+            use_staging=use_staging,
+            identity_token=identity_token,
+        )
+        return self

--- a/src/model_signing/verify.py
+++ b/src/model_signing/verify.py
@@ -1,0 +1,134 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""High level API for the verification interface of model_signing library.
+
+Users should use this API to verify the integrity of models, rather than using
+the internals of the library. We guarantee backwards compatibility only for the
+API defined in `hash.py`, `sign.py` and `verify.py` at the root level of the
+library.
+"""
+
+import os
+import pathlib
+import sys
+from typing import Optional
+
+from model_signing import hash
+from model_signing.signing import sign_sigstore as sigstore
+
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+
+def verify(
+    model_path: os.PathLike,
+    signature_path: os.PathLike,
+    *,
+    identity: str,
+    oidc_issuer: Optional[str] = None,
+    use_staging: bool = False,
+):
+    """Verifies that a model conforms to a signature.
+
+    Currently, this assumes signatures over DSSE, using Sigstore. We will add
+    support for more cases in a future change.
+
+    Args:
+        model_path: the path to the model to verify.
+        signature_path: the path to the signature to check.
+        identity: The expected identity that has signed the model.
+        oidc_issuer: The expected OpenID Connect issuer that provided the
+          certificate used for the signature.
+        use_staging: Use staging configurations, instead of production. This
+          is supposed to be set to True only when testing. Default is False.
+    """
+    VerificationConfig().set_sigstore_dsse_verifier(
+        identity=identity, oidc_issuer=oidc_issuer, use_staging=use_staging
+    ).verify(model_path, signature_path)
+
+
+class VerificationConfig:
+    """Configuration to use when verifying models against signatures.
+
+    The verification configuration is used to decouple between serialization
+    formats and verification types. Having configured the serialization format,
+    this configuration class supports setting up the verification parameters.
+    These should match the signing one.
+    """
+
+    def __init__(self):
+        """Initializes the default configuration for verification."""
+        self._hashing_config = hash.HashingConfig()
+        self._verifier = None
+
+    def verify(self, model_path: os.PathLike, signature_path: os.PathLike):
+        """Verifies that a model conforms to a signature.
+
+        Args:
+            model_path: the path to the model to verify.
+            signature_path: the path to the signature to check.
+        """
+        signature = sigstore.SigstoreSignature.read(
+            pathlib.Path(signature_path)
+        )
+        expected_manifest = self._verifier.verify(signature)
+        actual_manifest = self._hashing_config.hash(model_path)
+
+        if actual_manifest != expected_manifest:
+            raise ValueError("Signature mismatch")
+
+    def set_hashing_config(self, hashing_config: hash.HashingConfig) -> Self:
+        """Sets the new configuration for hashing models.
+
+        Args:
+            hashing_config: the new hashing configuration.
+
+        Returns:
+            The new signing configuration.
+        """
+        self._hashing_config = hashing_config
+        return self
+
+    def set_sigstore_dsse_verifier(
+        self,
+        *,
+        identity: str,
+        oidc_issuer: Optional[str] = None,
+        use_staging: bool = False,
+    ) -> Self:
+        """Configures the verification of a Sigstore signature over DSSE.
+
+        Only one verifier can be configured. Currently, we only support Sigstore
+        in the API, but the CLI supports signing with PKI, BYOK and no
+        signing/verification.  We will merge the configurations in a subsequent
+        change.
+
+        Args:
+            identity: The expected identity that has signed the model.
+            oidc_issuer: The expected OpenID Connect issuer that provided the
+              certificate used for the signature.
+            use_staging: Use staging configurations, instead of production. This
+              is supposed to be set to True only when testing. Default is False.
+
+        Return:
+            The new verification configuration.
+        """
+        self._verifier = sigstore.SigstoreDSSEVerifier(
+            identity=identity, oidc_issuer=oidc_issuer, use_staging=use_staging
+        )
+        return self

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -25,7 +25,8 @@ import time
 
 import pytest
 
-from model_signing import api as model_signing_api
+from model_signing import sign
+from model_signing import verify
 
 
 _MIN_VALIDITY = timedelta(minutes=1)
@@ -86,14 +87,15 @@ class TestSigstoreSigning:
     def test_sign_and_verify(
         self, sigstore_oidc_beacon_token, sample_model_folder, tmp_path
     ):
-        sc = model_signing_api.SigningConfig()
+        sc = sign.SigningConfig()
         sc.set_sigstore_signer(
             use_staging=True, identity_token=sigstore_oidc_beacon_token
         )
         signature_path = tmp_path / "model.sig"
         sc.sign(sample_model_folder, signature_path)
+
         expected_identity = "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main"
-        model_signing_api.verify(
+        verify.verify(
             sample_model_folder,
             signature_path,
             identity=expected_identity,


### PR DESCRIPTION
#### Summary

This simplifies the interface slightly as users can import only what they need (e.g., if they only care about hashing in their script they can just import the hashing API).

```python
import model_signing

model_signing.hash.hash(...)
```

This is just the first stage, I actually want the names to be `hashing`, `signing` and `verification`, but cannot do that at the moment, given we already have `hashing` as a directory. I'll send another PR to rename that to `_hashing` when we control more clearly what is the internal and what is the external API and then will clean this up. But first, I need to make sure the public API supports all of our needs for V1.

#### Release Note
NONE

#### Documentation
NONE