### PR TITLE
Fix typo, add space

### DIFF
--- a/src/model_signing/signature/pki.py
+++ b/src/model_signing/signature/pki.py
@@ -184,7 +184,7 @@ class PKIVerifier(Verifier):
                 pass
             if not code_signing:
                 raise VerificationError(
-                    "signing certificate neither allows digital signature"
+                    "signing certificate neither allows digital signature "
                     "nor code signing"
                 )
 


### PR DESCRIPTION
#### Summary
This just fixes the typo mentioned in #382. It's because Python's implicit concatenation does not add a space, we need to add it ourselves.

#### Release Note
NONE
#### Documentation
NONE