### PR TITLE
Don't ignore md files in CI for model signing.

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,9 +17,6 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize]
-    paths-ignore:
-      - '**/*.md'
-      - '*.md'
 
 permissions: {}
 


### PR DESCRIPTION
#### Summary
These CI tests are required, so we need to make sure they get triggered even for documentation only PRs.

See #387 for a case where they are stuck.

#### Release Note
NONE

#### Documentation
NONE
