### PR TITLE
ECKeySigner: Filter keys by supported curves and use their parameters

### DIFF
--- a/README.model_signing.md
+++ b/README.model_signing.md
@@ -81,14 +81,14 @@ $ source .venv/bin/activate
 ```bash
 $ MODEL_PATH='/path/to/your/model'
 $ SIG_PATH='./model.sig'
-$ openssl ecparam -name secp256k1 -genkey -noout -out ec-secp256k1-priv-key.pem
-$ openssl ec -in ec-secp256k1-priv-key.pem -pubout > ec-secp256k1-pub-key.pem
+$ openssl ecparam -name secp256r1 -genkey -noout -out ec-secp256r1-priv-key.pem
+$ openssl ec -in ec-secp256r1-priv-key.pem -pubout > ec-secp256r1-pub-key.pem
 $ source .venv/bin/activate
 # SIGN
-(.venv) $ python3 -m model_signing sign key --signature ${SIG_PATH} --private_key ec-secp256k1-priv-key.pem ${MODEL_PATH}
+(.venv) $ python3 -m model_signing sign key --signature ${SIG_PATH} --private_key ec-secp256r1-priv-key.pem ${MODEL_PATH}
 ...
 #VERIFY
-(.venv) $ python3 -m model_signing verify key --signature ${SIG_PATH} --public_key ec-secp256k1-pub-key.pem ${MODEL_PATH}
+(.venv) $ python3 -m model_signing verify key --signature ${SIG_PATH} --public_key ec-secp256r1-pub-key.pem ${MODEL_PATH}
 ...
 ```
 

--- a/src/model_signing/signature/utils.py
+++ b/src/model_signing/signature/utils.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2025, IBM CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.hashes import SHA384
+from cryptography.hazmat.primitives.hashes import SHA512
+from cryptography.hazmat.primitives.hashes import HashAlgorithm
+from sigstore_protobuf_specs.dev.sigstore.common import v1 as common_pb
+
+
+def get_ec_key_params(
+    public_key: ec.EllipticCurvePublicKey,
+) -> tuple[HashAlgorithm, common_pb.PublicKeyDetails]:
+    key_size = public_key.curve.key_size
+    if key_size == 256:
+        return SHA256(), common_pb.PublicKeyDetails.PKIX_ECDSA_P256_SHA_256
+    elif key_size == 384:
+        return SHA384(), common_pb.PublicKeyDetails.PKIX_ECDSA_P384_SHA_384
+    elif key_size == 521:
+        return SHA512(), common_pb.PublicKeyDetails.PKIX_ECDSA_P521_SHA_512
+    raise ValueError(f"Unexpected key size {key_size}")
+
+
+def check_supported_ec_key(public_key: ec.EllipticCurvePublicKey):
+    curve = public_key.curve.name
+    if curve not in ["secp256r1", "secp384r1", "secp521r1"]:
+        raise ValueError(f"Unsupported key for curve '{curve}'")

--- a/tests/signature/key_test.py
+++ b/tests/signature/key_test.py
@@ -14,6 +14,9 @@
 # flake8: noqa: E712
 import pathlib
 
+from cryptography.hazmat.primitives.serialization.base import (
+    load_pem_public_key,
+)
 from in_toto_attestation.v1 import resource_descriptor as res_desc
 from in_toto_attestation.v1 import statement
 import pytest
@@ -24,14 +27,14 @@ from model_signing.signature.verifying import VerificationError
 
 
 _PRIV_KEY_1 = b"""-----BEGIN EC PRIVATE KEY-----
-MHQCAQEEIDcpvDIigb10Ys3SbkoAd+yquWkiu/GW4Qx495pnsZh4oAcGBSuBBAAK
-oUQDQgAEU+HLGtq3jwrv3i3oT7pq3NAMnfoWBuPOeeiZOl32+7dpuhkbXs4nTDSC
-kUd2RjIbO7kAeFjJfMpmZEgMwkH/dw==
+MHcCAQEEIFcw5db1a1azLGwJaawU+n1dh+Wj5BfeZrJhZ/JP8hqJoAoGCCqGSM49
+AwEHoUQDQgAEL8phBNVmtxDpvDIddL8HweqpzjcBUL15HESpzhFK+9Uy//Rclvwj
+evHmjyMtsKfBPUCWNJLJ4/0FhcnYGcj9YQ==
 -----END EC PRIVATE KEY-----
 """
 _PUB_KEY_1 = b"""-----BEGIN PUBLIC KEY-----
-MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEU+HLGtq3jwrv3i3oT7pq3NAMnfoWBuPO
-eeiZOl32+7dpuhkbXs4nTDSCkUd2RjIbO7kAeFjJfMpmZEgMwkH/dw==
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEL8phBNVmtxDpvDIddL8HweqpzjcB
+UL15HESpzhFK+9Uy//RclvwjevHmjyMtsKfBPUCWNJLJ4/0FhcnYGcj9YQ==
 -----END PUBLIC KEY-----
 """
 _PUB_KEY_2 = b"""-----BEGIN PUBLIC KEY-----
@@ -100,7 +103,7 @@ def test_key_signature_wrong_key(tmp_path: pathlib.Path):
     stmnt = __get_stmnt()
 
     signer = ECKeySigner.from_path(priv_key_path)
-    verifier = ECKeyVerifier(_PUB_KEY_2)
+    verifier = ECKeyVerifier(load_pem_public_key(_PUB_KEY_2))
 
     bdl = signer.sign(stmnt)
 


### PR DESCRIPTION
Per the PublicKeyDetails enum from sigstore only NIST P256/384/521 are supported via the following:

    PKIX_ECDSA_P256_SHA_256 = 5; // See NIST FIPS 186-4
    PKIX_ECDSA_P384_SHA_384 = 12;
    PKIX_ECDSA_P521_SHA_512 = 13;

Therefore, check for supported curves and raise an error if the user wants to use an unsupported curve. Also, use curve-specific parameters, such as the hash and the above-shown identifier when signing.

Link: https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_common.proto
