### PR TITLE
Only run SLSA CI for SLSA related changes.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,9 +17,6 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize]
-    paths-ignore:
-      - '**/*.md'
-      - '*.md'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,6 +18,9 @@ on:
     branches: [main]
     types: [opened, synchronize]
   workflow_dispatch:
+  paths-ignore:
+     - '**/*.md'
+     - '*.md'
 
 permissions: {}
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,10 +17,10 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize]
+    paths-ignore:
+      - '**/*.md'
+      - '*.md'
   workflow_dispatch:
-  paths-ignore:
-     - '**/*.md'
-     - '*.md'
 
 permissions: {}
 

--- a/.github/workflows/slsa_for_ml.yml
+++ b/.github/workflows/slsa_for_ml.yml
@@ -35,6 +35,7 @@ on:
       - '*.md'
     paths:
       - 'slsa_for_models/**'
+      - '.github/workflows/slsa_for_ml.yml'
 
 permissions: {}
 

--- a/.github/workflows/slsa_for_ml.yml
+++ b/.github/workflows/slsa_for_ml.yml
@@ -33,6 +33,13 @@ on:
     paths-ignore:
       - '**/*.md'
       - '*.md'
+      # TODO: We only want to run this workflow only for SLSA changes
+      # For now, just disable it from any other location, but in the future
+      # when we restart the work on SLSA we will need to be more accurate here.
+      - 'src/'
+      - 'tests/'
+      - 'docs/'
+      - 'benchmarks/'
 
 permissions: {}
 

--- a/.github/workflows/slsa_for_ml.yml
+++ b/.github/workflows/slsa_for_ml.yml
@@ -33,13 +33,8 @@ on:
     paths-ignore:
       - '**/*.md'
       - '*.md'
-      # TODO: We only want to run this workflow only for SLSA changes
-      # For now, just disable it from any other location, but in the future
-      # when we restart the work on SLSA we will need to be more accurate here.
-      - 'src/'
-      - 'tests/'
-      - 'docs/'
-      - 'benchmarks/'
+    paths:
+      - 'slsa_for_models/**'
 
 permissions: {}
 


### PR DESCRIPTION
#### Summary
Given that we are working 99.9999% on model signing, it does not make sense to keep training models in CI and generating SLSA provenances for them. We will revisit this when we restart work on SLSA for ML.

#### Release Note
NONE
#### Documentation
NONE