### PR TITLE
setup workflow to sign and verify on different OS

### DIFF
--- a/.github/workflows/cross_os.yml
+++ b/.github/workflows/cross_os.yml
@@ -1,0 +1,117 @@
+# Copyright 2025 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Run cross OS sign and verify
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+    paths-ignore:
+      - '**/*.md'
+      - '*.md'
+  workflow_dispatch:
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  generate-model:
+    runs-on: ubuntu-latest
+    steps:
+      - name: generate model
+        id: model
+        run: |
+          set -e
+          MODEL_ROOT=$(mktemp --directory)
+          echo "root=$MODEL_ROOT" >> "$GITHUB_OUTPUT"
+          for i in {0..1}; do
+              DIR="${MODEL_ROOT}/d${i}"
+              mkdir "$DIR"
+              for j in {0..2}; do
+                  echo "This is file f${i}${j} in d${i}." > "${DIR}/f${i}${j}"
+              done
+          done
+          for i in {0..3}; do
+              echo "This is file f${i} in root." > "${MODEL_ROOT}/f${i}"
+          done
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          path: ${{ steps.model.outputs.root }}
+          name: model.zip
+          if-no-files-found: error
+          retention-days: 1
+  model-signing:
+    name: Signing with ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
+    needs: [generate-model]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # Don't cancel other jobs if one fails
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: model.zip
+          path: model_root/
+      - name: Set up Hatch
+        uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
+      - name: store beacon token into oidc-token.txt
+        uses: sigstore-conformance/extremely-dangerous-public-oidc-beacon@b517a742e5a3db9e3cbf8e2e1c792b36982f78db # main
+      - name: Sign the model
+        run: hatch run python -m model_signing sign sigstore model_root/ --use_staging --signature model.sig --identity_token $(cat oidc-token.txt)
+      - name: upload model signature
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ matrix.os }}-model.sig
+          path: model.sig
+          if-no-files-found: error
+          retention-days: 1
+  model-verification:
+    name: Verifying with ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
+    if: ${{ always() }} # don't stop some verification if one of the signing jobs failed
+    needs: [generate-model, model-signing]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # Don't cancel other jobs if one fails
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        signed-with-os: [ubuntu-latest, macos-latest, windows-latest]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: model.zip
+          path: model_root/
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: ${{ matrix.signed-with-os }}-model.sig
+      - name: Set up Hatch
+        uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
+      - name: Verify the model
+        run: |
+          hatch run python -m model_signing verify sigstore model_root/ --use_staging --signature model.sig \
+            --identity "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main" \
+            --identity_provider "https://token.actions.githubusercontent.com"


### PR DESCRIPTION
#### Summary

Use the CLI to sign a toy model on Linux, macOS, and Windows, then use all three OSes to verify each signature. This tests every combination between the two.

Fixes #25

#### Release Note
NONE

#### Documentation
NONE
