### PR TITLE
Simplify payload to manifest transformation

### DIFF
--- a/src/model_signing/signing/in_toto_signature.py
+++ b/src/model_signing/signing/in_toto_signature.py
@@ -49,7 +49,7 @@ class IntotoSignature(signing.Signature):
 
     def to_manifest(self) -> manifest.Manifest:
         payload = json.loads(self._bundle.dsse_envelope.payload)
-        return signing.Payload.manifest_from_payload(payload)
+        return signing.dsse_payload_to_manifest(payload)
 
 
 class IntotoSigner(signing.Signer):

--- a/src/model_signing/signing/sign_sigstore.py
+++ b/src/model_signing/signing/sign_sigstore.py
@@ -234,4 +234,4 @@ class SigstoreVerifier(signing.Verifier):
                 f"but got {payload['_type']}"
             )
 
-        return signing.Payload.manifest_from_payload(payload)
+        return signing.dsse_payload_to_manifest(payload)

--- a/src/model_signing/signing/signing.py
+++ b/src/model_signing/signing/signing.py
@@ -39,7 +39,7 @@ https://docs.sigstore.dev/about/bundle/.
 import abc
 import pathlib
 import sys
-from typing import Any, Final
+from typing import Any
 
 from in_toto_attestation.v1 import statement
 
@@ -52,6 +52,10 @@ if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self
+
+
+# The expected model signature predicate type.
+_PREDICATE_TYPE: str = "https://model_signing/signature/v1.0"
 
 
 def dsse_payload_to_manifest(dsse_payload: dict[str, Any]) -> manifest.Manifest:
@@ -70,9 +74,9 @@ def dsse_payload_to_manifest(dsse_payload: dict[str, Any]) -> manifest.Manifest:
         ValueError: If the payload cannot be deserialized to a manifest.
     """
     obtained_predicate_type = dsse_payload["predicateType"]
-    if obtained_predicate_type != Payload.predicate_type:
+    if obtained_predicate_type != _PREDICATE_TYPE:
         raise ValueError(
-            f"Predicate type mismatch, expected {Payload.predicate_type}, "
+            f"Predicate type mismatch, expected {_PREDICATE_TYPE}, "
             f"got {obtained_predicate_type}"
         )
 
@@ -185,9 +189,6 @@ class Payload:
     ```
     """
 
-    predicate_type: Final[str] = "https://model_signing/signature/v1.0"
-    statement: Final[statement.Statement]
-
     def __init__(self, manifest: manifest.Manifest):
         """Builds an instance of this in-toto payload.
 
@@ -219,7 +220,7 @@ class Payload:
 
         self.statement = statement.Statement(
             subjects=[subject],
-            predicate_type=self.predicate_type,
+            predicate_type=_PREDICATE_TYPE,
             predicate=predicate,
         )
 

--- a/src/model_signing/signing/signing.py
+++ b/src/model_signing/signing/signing.py
@@ -18,24 +18,22 @@ The serialization API produces a manifest representation of the models, and we
 use that to implement integrity checking of models in different computational
 patterns. This means that all manifests need to be kept only in memory.
 
-For signing, we need to convert the manifest to the signing payload. We only
-support manifests serialized to in-toto formats described by
-https://github.com/in-toto/attestation/tree/main/spec/v1. The envelope format
-is DSSE, as described in https://github.com/secure-systems-lab/dsse.
-
 Since we need to support multiple signing methods (e.g., Sigstore, key,
 certificate, etc.) , we provide a `Signer` abstract class with a single `sign`
 method that takes a signing payload and converts it to a signature in the
 supported format.
 
-Every possible signature will be implemented as a subclass of `Signature` class.
-The API for signatures only allows writing them to disk and parsing them from a
-given path.
-TODO: only one signature is supported!
-
 Finally, every signature needs to be verified. We pair every `Signer` subclass
 with a `Verifier` which takes a signature, verify the authenticity of the
 payload and then expand that to a manifest.
+
+Regarding the data formats, for signing, we need to convert the manifest to the
+signing payload. We only support manifests serialized to in-toto formats
+described by https://github.com/in-toto/attestation/tree/main/spec/v1. The
+envelope format is DSSE, as described in
+https://github.com/secure-systems-lab/dsse. The signature is in a Sigstore
+bundle format over the DSSE payload. The format is described at
+https://docs.sigstore.dev/about/bundle/.
 """
 
 import abc
@@ -54,6 +52,59 @@ if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self
+
+
+def dsse_payload_to_manifest(dsse_payload: dict[str, Any]) -> manifest.Manifest:
+    """Builds a manifest from the DSSE payload read from a signature.
+
+    The payload here is a dictionary that represents the payload part of the
+    DSSE envelope contained in the Sigstore bundle.
+
+    Args:
+        payload: The in-toto DSSE envelope to convert to manifest.
+
+    Returns:
+        A manifest representing the signed model.
+
+    Raises:
+        ValueError: If the payload cannot be deserialized to a manifest.
+    """
+    obtained_predicate_type = dsse_payload["predicateType"]
+    if obtained_predicate_type != Payload.predicate_type:
+        raise ValueError(
+            f"Predicate type mismatch, expected {Payload.predicate_type}, "
+            f"got {obtained_predicate_type}"
+        )
+
+    subjects = dsse_payload["subject"]
+    if len(subjects) != 1:
+        raise ValueError(f"Expected only one subject, got {subjects}")
+
+    model_name = subjects[0]["name"]
+    expected_digest = subjects[0]["digest"]["sha256"]
+
+    predicate = dsse_payload["predicate"]
+    serialization_args = predicate["serialization"]
+    serialization = manifest.SerializationType.from_args(serialization_args)
+
+    hasher = memory.SHA256()
+    items = []
+    for resource in predicate["resources"]:
+        name = resource["name"]
+        algorithm = resource["algorithm"]
+        digest_value = resource["digest"]
+        digest = hashing.Digest(algorithm, bytes.fromhex(digest_value))
+        hasher.update(digest.digest_value)
+        items.append(serialization.new_item(name, digest))
+
+    obtained_digest = hasher.compute().digest_hex
+    if obtained_digest != expected_digest:
+        raise ValueError(
+            f"Manifest is inconsistent. Root digest is {expected_digest}, "
+            f"but the included resources hash to {obtained_digest}"
+        )
+
+    return manifest.Manifest(model_name, items, serialization)
 
 
 class Payload:
@@ -171,58 +222,6 @@ class Payload:
             predicate_type=self.predicate_type,
             predicate=predicate,
         )
-
-    @classmethod
-    def manifest_from_payload(
-        cls, payload: dict[str, Any]
-    ) -> manifest.Manifest:
-        """Builds a manifest from an in-memory in-toto payload.
-
-        Args:
-            payload: the in memory in-toto payload to build a manifest from.
-
-        Returns:
-            A manifest that can be converted back to the same payload.
-
-        Raises:
-            ValueError: If the payload cannot be deserialized to a manifest.
-        """
-        obtained_predicate_type = payload["predicateType"]
-        if obtained_predicate_type != cls.predicate_type:
-            raise ValueError(
-                f"Predicate type mismatch, expected {cls.predicate_type}, "
-                f"got {obtained_predicate_type}"
-            )
-
-        subjects = payload["subject"]
-        if len(subjects) != 1:
-            raise ValueError(f"Expected only one subject, got {subjects}")
-
-        model_name = subjects[0]["name"]
-        expected_digest = subjects[0]["digest"]["sha256"]
-
-        predicate = payload["predicate"]
-        serialization_args = predicate["serialization"]
-        serialization = manifest.SerializationType.from_args(serialization_args)
-
-        hasher = memory.SHA256()
-        items = []
-        for resource in predicate["resources"]:
-            name = resource["name"]
-            algorithm = resource["algorithm"]
-            digest_value = resource["digest"]
-            digest = hashing.Digest(algorithm, bytes.fromhex(digest_value))
-            hasher.update(digest.digest_value)
-            items.append(serialization.new_item(name, digest))
-
-        obtained_digest = hasher.compute().digest_hex
-        if obtained_digest != expected_digest:
-            raise ValueError(
-                f"Manifest is inconsistent. Root digest is {expected_digest}, "
-                f"but the included resources hash to {obtained_digest}"
-            )
-
-        return manifest.Manifest(model_name, items, serialization)
 
 
 class Signature(metaclass=abc.ABCMeta):


### PR DESCRIPTION
#### Summary
Rather than using the `Payload` class to call a static class method, convert that to a free function. We can do that since we only support one single signature format and the entire signature format is localized within the `signing` and `signature` directories (to be merged).

I'm also extracting the predicate type to a global of the module instead of accessing it via the `Payload` class. It's local to the module, so that's ok.

We'll keep the `Payload` class though since otherwise we'd need to use the in-toto statement import in multiple other places, outside of the `signing`/`signature` directories and their tests.

Only the last 2 commits are new here (from "Free function instead of manifest_from_payload"). The rest is #408

#### Release Note
NONE

#### Documentation
NONE
