### PR TITLE
Enable signing with PKCS #11 devices (HSMs)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,5 +50,6 @@ jobs:
         set -euxo pipefail
         if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
           sudo apt install softhsm2 gnutls-bin
+          ./scripts/pkcs11-tests/softhsm_setup setup
         fi
         hatch test -c -py ${{ matrix.python-version }} -m integration

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,4 +48,7 @@ jobs:
     - name: Run integration tests
       run: |
         set -euxo pipefail
+        if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+          sudo apt install softhsm2 gnutls-bin
+        fi
         hatch test -c -py ${{ matrix.python-version }} -m integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,11 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
+  "asn1crypto",
   "click",
   "cryptography",
   "in-toto-attestation",
+  "PyKCS11",
   "sigstore",
   "typing_extensions",
 ]

--- a/scripts/pkcs11-tests/softhsm_setup
+++ b/scripts/pkcs11-tests/softhsm_setup
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+
+# For the license, see the LICENSE file in the root directory.
+
+# This script may not work with softhsm2 2.0.0 but with >= 2.2.0
+
+if [ -z "$(type -P p11tool)" ]; then
+	echo "Need p11tool from gnutls"
+	exit 77
+fi
+
+if [ -z "$(type -P softhsm2-util)" ]; then
+	echo "Need softhsm2-util from softhsm2 package"
+	exit 77
+fi
+
+NAME=model-signing-test
+PIN=${PIN:-1234}
+SO_PIN=${SO_PIN:-1234}
+SOFTHSM_SETUP_CONFIGDIR=${SOFTHSM_SETUP_CONFIGDIR:-~/.config/softhsm2}
+export SOFTHSM2_CONF=${SOFTHSM_SETUP_CONFIGDIR}/softhsm2.conf
+
+UNAME_S="$(uname -s)"
+
+case "${UNAME_S}" in
+Darwin)
+	if ! msg=$(sudo -v -n); then
+		echo "Need password-less sudo rights on OS X to change /etc/gnutls/pkcs11.conf"
+		exit 1
+	fi
+	;;
+esac
+
+teardown_softhsm() {
+	local configdir=${SOFTHSM_SETUP_CONFIGDIR}
+	local configfile=${SOFTHSM2_CONF}
+	local bakconfigfile=${configfile}.bak
+	local tokendir=${configdir}/tokens
+
+	softhsm2-util --token "${NAME}" --delete-token &>/dev/null
+
+	case "${UNAME_S}" in
+	Darwin*)
+		if [ -f /etc/gnutls/pkcs11.conf.bak ]; then
+			sudo rm -f /etc/gnutls/pkcs11.conf
+			sudo mv /etc/gnutls/pkcs11.conf.bak \
+			   /etc/gnutls/pkcs11.conf &>/dev/null
+		fi
+		;;
+	esac
+
+	if [ -f "$bakconfigfile" ]; then
+		mv "$bakconfigfile" "$configfile"
+	else
+		rm -f "$configfile"
+	fi
+	if [ -d "$tokendir" ]; then
+		rm -rf "${tokendir}"
+	fi
+	return 0
+}
+
+setup_softhsm() {
+	local msg tokenuri keyuri
+	local configdir=${SOFTHSM_SETUP_CONFIGDIR}
+	local configfile=${SOFTHSM2_CONF}
+	local bakconfigfile=${configfile}.bak
+	local tokendir=${configdir}/tokens
+	local rc
+
+	case "${UNAME_S}" in
+	Darwin*)
+		if [ -f /etc/gnutls/pkcs11.conf.bak ]; then
+			echo "/etc/gnutls/pkcs11.conf.bak already exists; need to 'teardown' first"
+			return 1
+		fi
+		sudo mv /etc/gnutls/pkcs11.conf \
+			/etc/gnutls/pkcs11.conf.bak &>/dev/null
+		if [ "$(id -u)" -eq 0 ]; then
+			SONAME="$(sudo -u nobody brew ls --verbose softhsm | \
+				  grep -E "\.so$")"
+		else
+			SONAME="$(brew ls --verbose softhsm | \
+				  grep -E "\.so$")"
+		fi
+		sudo mkdir -p /etc/gnutls &>/dev/null
+		sudo bash -c "echo 'load=${SONAME}' > /etc/gnutls/pkcs11.conf"
+		;;
+	esac
+
+	if ! [ -d "$configdir" ]; then
+		mkdir -p "$configdir"
+	fi
+	mkdir -p "${tokendir}"
+
+	if [ -f "$configfile" ]; then
+		mv "$configfile" "$bakconfigfile"
+	fi
+
+	if ! [ -f "$configfile" ]; then
+		cat <<_EOF_ > "$configfile"
+directories.tokendir = ${tokendir}
+objectstore.backend = file
+log.level = DEBUG
+slots.removable = false
+_EOF_
+	fi
+
+	if ! msg=$(p11tool --list-tokens 2>&1 | grep "token=${NAME}" | tail -n1); then
+		echo "Could not list existing tokens"
+		echo "$msg"
+	fi
+	tokenuri=$(echo "$msg" | sed -n 's/.*URL: \([[:print:]*]\)/\1/p')
+
+	if [ -z "$tokenuri" ]; then
+		if ! msg=$(softhsm2-util \
+			   --init-token --pin "${PIN}" --so-pin "${SO_PIN}" \
+			   --free --label "${NAME}" 2>&1); then
+			echo "Could not initialize token"
+			echo "$msg"
+			return 2
+		fi
+
+		slot=$(echo "$msg" | \
+		       sed -n 's/.* reassigned to slot \([0-9]*\)$/\1/p')
+		if [ -z "$slot" ]; then
+			slot=$(softhsm2-util --show-slots | \
+			       grep -E "^Slot " | head -n1 |
+			       sed -n 's/Slot \([0-9]*\)/\1/p')
+			if [ -z "$slot" ]; then
+				echo "Could not parse slot number from output."
+				echo "$msg"
+				return 3
+			fi
+		fi
+
+		if ! msg=$(p11tool --list-tokens 2>&1 | \
+			   grep "token=${NAME}" | tail -n1); then
+			echo "Could not list existing tokens"
+			echo "$msg"
+		fi
+		tokenuri=$(echo "$msg" | sed -n 's/.*URL: \([[:print:]*]\)/\1/p')
+		if [ -z "${tokenuri}" ]; then
+			echo "Could not get tokenuri!"
+			return 4
+		fi
+
+		# more recent versions of p11tool have --generate-privkey ...
+		if ! msg=$(GNUTLS_PIN=$PIN p11tool \
+			   --generate-privkey=ecdsa --curve secp384r1 --label mykey --login \
+			"${tokenuri}" 2>&1);
+		then
+			echo "Could not create secp384r1 key!"
+			echo "$msg"
+			return 5
+		fi
+	fi
+
+	getkeyuri_softhsm "$slot"
+	rc=$?
+	if [ $rc -ne 0 ]; then
+		teardown_softhsm
+	fi
+
+	return $rc
+}
+
+_getkeyuri_softhsm() {
+	local msg tokenuri keyuri
+
+	if ! msg=$(p11tool --list-tokens 2>&1 | grep "token=${NAME}"); then
+		echo "Could not list existing tokens"
+		echo "$msg"
+		return 5
+	fi
+	tokenuri=$(echo "$msg" | sed -n 's/.*URL: \([[:print:]*]\)/\1/p')
+	if [ -z "$tokenuri" ]; then
+		echo "Could not get token URL"
+		echo "$msg"
+		return 6
+	fi
+	if ! msg=$(p11tool --list-all "${tokenuri}" 2>&1); then
+		echo "Could not list object under token $tokenuri"
+		echo "$msg"
+		softhsm2-util --show-slots
+		return 7
+	fi
+
+	keyuri=$(echo "$msg" | sed -n 's/.*URL: \([[:print:]*]\)/\1/p')
+	if [ -z "$keyuri" ]; then
+		echo "Could not get key URL"
+		echo "$msg"
+		return 8
+	fi
+	echo "$keyuri"
+	return 0
+}
+
+getkeyuri_softhsm() {
+	local keyuri rc
+
+	keyuri=$(_getkeyuri_softhsm)
+	rc=$?
+	if [ $rc -ne 0 ]; then
+		return $rc
+	fi
+	echo "keyuri: $keyuri?pin-value=${PIN}&module-name=softhsm2"
+	return 0
+}
+
+getpubkey_softhsm() {
+	local keyuri rc
+
+	keyuri=$(_getkeyuri_softhsm)
+	rc=$?
+	if [ $rc -ne 0 ]; then
+		return $rc
+	fi
+	GNUTLS_PIN=${PIN} p11tool --export-pubkey "${keyuri}" --login 2>/dev/null
+	return $?
+}
+
+usage() {
+	cat <<_EOF_
+Usage: $0 [command]
+
+Supported commands are:
+
+setup      : Setup the user's account for softhsm and create a
+             token and key with a test configuration
+
+getkeyuri  : Get the key's URI; may only be called after setup
+
+getpubkey  : Get the public key in PEM format; may only be called after setup
+
+teardown   : Remove the temporary softhsm test configuration
+
+_EOF_
+}
+
+main() {
+	local ret
+
+	if [ $# -lt 1 ]; then
+		usage "$0"
+		echo -e "Missing command.\n\n"
+		return 1
+	fi
+	case "$1" in
+	setup)
+		setup_softhsm
+		ret=$?
+		;;
+	getkeyuri)
+		getkeyuri_softhsm
+		ret=$?
+		;;
+	getpubkey)
+		getpubkey_softhsm
+		ret=$?
+		;;
+	teardown)
+		teardown_softhsm
+		ret=$?
+		;;
+	*)
+		echo -e "Unsupported command: $1\n\n"
+		usage "$0"
+		ret=1
+	esac
+	return $ret
+}
+
+main "$@"
+exit $?

--- a/scripts/pkcs11-tests/test_pkcs11.sh
+++ b/scripts/pkcs11-tests/test_pkcs11.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+DIR=$(dirname "$0")
+
+PATH=$PATH:${PWD}/${DIR}
+TMPDIR=$(mktemp -d) || exit 1
+
+cleanup() {
+	softhsm_setup teardown &>/dev/null
+	rm -rf "${TMPDIR}"
+}
+trap cleanup SIGTERM EXIT
+
+if ! msg=$(softhsm_setup setup); then
+	echo -e "Could not setup softhsm:\n${msg}"
+	exit 77
+fi
+pkcs11uri=$(echo "${msg}" | sed -n 's|^keyuri: \(.*\)|\1|p')
+
+model_sig=${TMPDIR}/model.sig
+pub_key=${TMPDIR}/pubkey.pem
+model_path=${TMPDIR}
+
+if ! msg=$(softhsm_setup getpubkey > "${pub_key}"); then
+	echo -e "Could not get public key:\n${msg}"
+	exit 77
+fi
+
+if ! python -m model_signing sign pkcs11-key \
+	--signature "${model_sig}" \
+	--pkcs11_uri "${pkcs11uri}" \
+	"${model_path}"; then
+	echo "Could not sign."
+	exit 77
+fi
+
+if ! python -m model_signing verify key \
+	--signature "${model_sig}" \
+	--public_key "${pub_key}"  \
+	"${model_path}"; then
+	echo "Could not verify signature."
+	exit 77
+fi
+
+exit 0

--- a/src/model_signing/_signing/pkcs11uri.py
+++ b/src/model_signing/_signing/pkcs11uri.py
@@ -1,0 +1,475 @@
+# Copyright (c) 2025, IBM CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functionality to parse PKCS #11 URIs and access its components."""
+
+from collections.abc import Iterable
+import glob
+import os
+from os import stat
+import re
+from stat import S_ISREG
+from typing import Optional
+from urllib import parse
+from urllib.parse import urlparse
+
+import PyKCS11
+
+
+def escape_all(s: str) -> str:
+    """PCT-escape all characters in the given string; used primarily for Id."""
+    res = ""
+    for c in s:
+        o = ord(c) & 0xFF
+        res += f"%{o:02X}"
+
+    return res
+
+
+def escape(s: str, is_path: bool) -> str:
+    """PCT-escape the given string considering path or query attribute."""
+    res = ""
+    for c in s:
+        if (
+            (
+                (c >= "a" and c <= "z")
+                or (c >= "A" and c <= "Z")
+                or (c >= "0" and c <= "9")
+            )
+            or (is_path and c == "&")
+            or (not is_path and (c in ["/", "?", "|"]))
+        ):
+            res += c
+        else:
+            if c in ["-", ".", "_", "~"] or c in [
+                ":",
+                "[",
+                "]",
+                "@",
+                "!",
+                "$",
+                "'",
+                "(",
+                ")",
+                "*",
+                "+",
+                ",",
+                "=",
+            ]:  # unreserved per RFC 3986 sec. 2.3
+                res += c
+            else:
+                o = ord(c) & 0xFF
+                res += f"%{o:02X}"
+
+    return res
+
+
+class Pkcs11URI:
+    def __init__(self):
+        self.reset()
+        self.module_directories = []
+        self.allowed_module_paths = []
+        self.allow_any_module = True
+
+    def reset(self) -> None:
+        """Clear path and query parameters of the URI."""
+        self.path_attributes = {}
+        self.query_attributes = {}
+
+    def get_attribute_bytes(
+        self, attr_map: dict[str, str], name: str
+    ) -> Optional[bytes]:
+        """Get an attribute in form of bytes, if available."""
+        if name not in attr_map:
+            return None
+        vb = b""
+        for c in attr_map[name]:
+            vb += ord(c).to_bytes(length=1, byteorder="big")
+        return vb
+
+    def get_path_attribute_bytes(self, name: str) -> Optional[bytes]:
+        """Get a path attribute as <bytes>."""
+        return self.get_attribute_bytes(self.path_attributes, name)
+
+    def get_query_attribute_bytes(self, name: str) -> Optional[bytes]:
+        """Get a query attribute as <bytes>."""
+        return self.get_attribute_bytes(self.query_attributes, name)
+
+    def set_attribute(
+        self,
+        attr_map: dict[str, str],
+        name: str,
+        value: str,
+        is_path: bool = False,
+        pctencode: bool = False,
+    ) -> None:
+        if pctencode:
+            value = escape(value, is_path)
+        """Set an attribute in the given dictionary."""
+        # RFC7512 section 2.3: only 'id' may contain non-textual data
+        # However, URI on page 15 shows a token with 'acute:%20>>%C3%A1<<' in
+        # the name.
+        # -> Only 'id' is relevant for user to have as bytes, all other ones can
+        #    be given back as strings or pct-encoded
+        vb = parse.unquote_to_bytes(value)
+
+        v = ""
+        for c in vb:
+            v += chr(c)
+        attr_map[name] = v
+
+    def get_path_attribute(
+        self, name: str, pctencode: bool = False
+    ) -> Optional[str]:
+        """Get a path attribute by its name, possibly in pct-encode form."""
+        v = self.path_attributes.get(name)
+        if v is not None and pctencode:
+            v = escape(v, True)
+        return v
+
+    def set_path_attribute(
+        self, name: str, value: str, pctencode: bool = False
+    ) -> None:
+        """Set a path attribute."""
+        self.set_attribute(self.path_attributes, name, value, True, pctencode)
+
+    def set_path_attribute_unencoded(self, name: str, value: bytes) -> None:
+        """Set an unencoded path attribute as bytes."""
+        self.set_path_attribute(name, value.decode("utf-8"), True)
+
+    def add_path_attribute(
+        self, name: str, value: str, pctencode: bool = False
+    ) -> None:
+        """Add a path attrbuute given as a string."""
+        if name in self.path_attributes:
+            raise ValueError("duplicate path attribute")
+        self.set_path_attribute(name, value, pctencode)
+
+    def add_path_attribute_unencoded(self, name: str, value: bytes) -> None:
+        """Add an unencoded path attribute as bytes."""
+        if name in self.path_attributes:
+            raise ValueError("duplicate path attribute")
+        self.set_path_attribute_unencoded(name, value)
+
+    def remove_path_attribute(self, name: str) -> None:
+        """Remove a path attribute."""
+        if name in self.path_attributes:
+            del self.path_attributes[name]
+
+    def get_query_attribute(
+        self, name: str, pctencode: bool = False
+    ) -> Optional[str]:
+        """Get a query attribute by its name, possibly in pct-encode form."""
+        v = self.query_attributes.get(name)
+        if v is not None and pctencode:
+            v = escape(v, False)
+        return v
+
+    def set_query_attribute(
+        self, name: str, value: str, pctencode: bool = False
+    ) -> None:
+        """Set a query attribute."""
+        self.set_attribute(self.query_attributes, name, value, False, pctencode)
+
+    def set_query_attribute_unencoded(self, name: str, value: bytes) -> None:
+        """Set an unencoded query attribute as bytes."""
+        self.set_query_attribute(name, value.decode("utf-8"), True)
+
+    def add_query_attribute(
+        self, name: str, value: str, pctencode: bool = False
+    ) -> None:
+        """Add a query attribute given as a string. pctencode it if wanted."""
+        if name in self.query_attributes:
+            raise ValueError("duplicate query attribute")
+        self.set_query_attribute(name, value, pctencode)
+
+    def add_query_attribute_unencoded(self, name: str, value: bytes) -> None:
+        """Add an unencoded query attribute as bytes."""
+        if name in self.query_attributes:
+            raise ValueError("duplicate query attribute")
+        self.set_query_attribute_unencoded(name, value)
+
+    def remove_query_attribute(self, name: str) -> None:
+        """Remove a query attribute."""
+        if name in self.query_attributes:
+            del self.query_attributes[name]
+
+    def validate(self) -> None:
+        """Validate a Pkcs11URI.
+
+        Validate a Pkcs11URI object's attributes following RFC 7512 rules and
+        proper formatting of their values.
+        """
+        v = self.path_attributes.get("slot-id")
+        if v is not None and not any(i.isdigit() for i in v):
+            raise ValueError(f"slot-id must be a number: {v}")
+
+        v = self.path_attributes.get("library-version")
+        if v is not None and re.match("^[0-9]+(\\.[0-9]+)?$", v) is None:
+            raise ValueError(f"Invalid format for library-version '{v}'")
+
+        v = self.path_attributes.get("type")
+        if (
+            v is not None
+            and re.match("^(public|private|cert|secret-key|data)?$", v) is None
+        ):
+            raise ValueError(f"Invalid type '{v}'")
+
+        v1 = self.query_attributes.get("pin-source")
+        v2 = self.query_attributes.get("pin-value")
+        if v1 is not None and v2 is not None:
+            raise ValueError("URI must not contain pin-source and pin-value")
+
+        v = self.query_attributes.get("module-path")
+        if v is not None and not os.path.isabs(v):
+            raise ValueError(
+                f"path {v} of module-path attribute must be absolute"
+            )
+
+    def has_pin(self) -> bool:
+        """Check whether a PIN has been provided."""
+        return (
+            self.query_attributes.get("pin-value") is not None
+            or self.query_attributes.get("pin-source") is not None
+        )
+
+    def get_pin(self) -> str:
+        """Get the PIN to access an object for example."""
+        v = self.query_attributes.get("pin-value")
+        if v is not None:
+            return v
+
+        v = self.query_attributes.get("pin-source")
+        if v is not None:
+            up = urlparse(v)
+            if up.scheme in ["", "file"]:
+                if not os.path.isabs(up.path):
+                    raise ValueError(
+                        f"PIN URI path '{up.path}' is not absolute"
+                    )
+                with open(up.path) as f:
+                    return f.read()
+            else:
+                raise ValueError(
+                    f"PIN URI scheme {up.scheme} is not supported: {{v}}"
+                )
+
+        raise ValueError("Neither pin-source nor pin-value are available")
+
+    def parse(self, uri: str) -> None:
+        """Parse the given URI."""
+        if not uri.startswith("pkcs11:"):
+            raise ValueError(
+                f"Malformed pkcs11 URI: missing 'pkcs11:' prefix: {uri}"
+            )
+
+        self.reset()
+
+        parts = uri[7:].split("?", 1)
+
+        if len(parts[0]) > 0:
+            # parse path part
+            for part in parts[0].split(";"):
+                p = part.split("=", 1)
+                if len(p) != 2:
+                    raise ValueError(
+                        "Malformed pkcs11 URI: malformed path attribute"
+                    )
+                self.add_path_attribute(p[0], p[1])
+
+        if len(parts) == 2:
+            for part in parts[1].split("&"):
+                p = part.split("=", 1)
+                if len(p) != 2:
+                    raise ValueError(
+                        "Malformed pkcs11 URI: malformed query attribute"
+                    )
+                self.add_query_attribute(p[0], p[1])
+
+        self.validate()
+
+    def format_attributes(self, attr_map: dict[str, str], is_path: bool) -> str:
+        """Format the attributes in the given map."""
+        res = ""
+        for key, value in attr_map.items():
+            value = escape_all(value) if key == "id" else escape(value, is_path)
+            if len(res) > 0:
+                if is_path:
+                    res += ";"
+                else:
+                    res += "&"
+            res += key + "=" + value
+        return res
+
+    def format(self) -> str:
+        """Format the Pkcs11URI to a string."""
+        self.validate()
+        result = "pkcs11:" + self.format_attributes(self.path_attributes, True)
+        if len(self.query_attributes) > 0:
+            result += "?" + self.format_attributes(self.query_attributes, False)
+        return result
+
+    def __str__(self) -> str:
+        return self.format()
+
+    def set_module_directories(self, dirs: Iterable[str]) -> None:
+        """Set directories to search for pkcs11 modules."""
+        self.module_directories = dirs
+
+    def set_allowed_module_paths(self, allowed_paths: list[str]) -> None:
+        """Set the allowed paths for pkcs11 modules."""
+        self.allowed_module_paths = allowed_paths
+
+    def set_allow_any_module(self, allow_any_module: bool) -> None:
+        """Set the any module may be loaded."""
+        self.allow_any_module = allow_any_module
+
+    def _is_allowed_path(self, path: str, allowed_paths: list[str]) -> bool:
+        """Check whether the given path is allowed."""
+        if self.allow_any_module:
+            return True
+        for allowed_path in allowed_paths:
+            if allowed_path == path:
+                return True
+            print(allowed_path)
+            if allowed_path[-1] == os.path.sep and path.find(allowed_path) == 0:
+                try:
+                    path[len(allowed_path) :].index(os.path.sep)
+                except ValueError:
+                    return True
+        return False
+
+    def get_module(self) -> str:
+        """Get the pkcs11 module that is to be used."""
+        v = self.get_query_attribute("module-path")
+        if v is not None:
+            try:
+                statbuf = stat(v)
+                if S_ISREG(statbuf.st_mode):
+                    if self._is_allowed_path(v, self.allowed_module_paths):
+                        return v
+                    raise ValueError(
+                        f"module-path '{v}' is not allowed by policy"
+                    )
+                if not os.path.isdir(v):
+                    raise ValueError(
+                        f"module-path '{v}' points to an invlaid file type"
+                    )
+                searchdirs = [v]
+
+            except FileNotFoundError as err:
+                raise ValueError from err
+        else:
+            searchdirs = self.module_directories
+
+        module_name = self.get_query_attribute("module-name")
+        if module_name is None:
+            raise ValueError("module-name attribute is not set")
+        module_name = module_name.lower()
+
+        for dir in searchdirs:
+            files = glob.glob(os.path.join(dir, "*"))
+            for file in files:
+                file_lower = file.lower()
+                try:
+                    i = file_lower.index(module_name)
+                except ValueError:
+                    continue
+
+                if (
+                    len(file_lower) == i + len(module_name)
+                    or file_lower[i + len(module_name)] == "."
+                ):
+                    f = os.path.join(dir, file)
+                    if self._is_allowed_path(f, self.allowed_module_paths):
+                        return f
+                    raise ValueError(f"module '{f}' is not allowed by policy")
+        dirs = ", ".join(searchdirs)
+        raise ValueError(f"No module '{module_name}' could be found in {dirs}")
+
+    def get_keyid_and_label(self) -> tuple[Optional[bytes], Optional[str]]:
+        """Get the id for the key and its label."""
+        keyid = self.get_path_attribute_bytes("id")
+        label = self.get_path_attribute("object")
+        if keyid is None and label is None:
+            raise ValueError(
+                "Neither 'id' nor 'object' attributes were found in pkcs11 URI"
+            )
+        return keyid, label
+
+    def open_session(
+        self,
+        lib: PyKCS11.PyKCS11Lib,
+        slot_id: int,
+        pin: str,
+        token_label: Optional[str],
+    ) -> PyKCS11.Session:
+        """Open a session.
+
+        Open a session given a slot-id and an optional token label whose name
+        must match if given.
+        """
+        token = lib.getTokenInfo(slot_id)
+        if token_label is not None and token.label != f"{token_label:<32s}":
+            raise ValueError(
+                f"The token in slot {slot_id} is not called '{token_label}'"
+            )
+        session = lib.openSession(slot_id)
+        if pin is not None:
+            session.login(pin)
+        return session
+
+    def get_login_parameters(self) -> tuple[Optional[str], str, int]:
+        """Get the login parameters PIN, module, and slot-id from the URI."""
+        pin = None
+        if self.has_pin():
+            pin = self.get_pin()
+
+        module = self.get_module()
+
+        slotid = -1
+        v = self.get_path_attribute("slot-id")
+        if v is not None:
+            slotid = int(v)
+            if slotid < 0:
+                raise ValueError("slot-id is a negative number")
+            if slotid > 0xFFFFFFFF:
+                raise ValueError("slot-id is larger than 32 bit")
+
+        return pin, module, slotid
+
+    def login(self) -> tuple[PyKCS11.Session, PyKCS11.PyKCS11Lib]:
+        """Log in to the device using parameters from the URI."""
+        pin, module, slot_id = self.get_login_parameters()
+
+        lib = PyKCS11.PyKCS11Lib().load(pkcs11dll_filename=module)
+
+        token_label = self.get_path_attribute("token")
+
+        # If a slot-id is given, use it to open the session
+        if slot_id >= 0:
+            return self.open_session(lib, slot_id, pin, token_label), lib
+
+        if token_label is None:
+            raise ValueError("Need a token due to missing slot-id")
+
+        for slot in lib.getSlotList():
+            token = lib.getTokenInfo(slot)
+            if token.label == f"{token_label:<32s}":
+                session = lib.openSession(slot)
+                if pin is not None:
+                    session.login(pin)
+                return session, lib
+        raise ValueError(
+            f"Could not find a token with label {token_label} in any slots"
+        )

--- a/src/model_signing/_signing/sign_pkcs11.py
+++ b/src/model_signing/_signing/sign_pkcs11.py
@@ -1,0 +1,277 @@
+# Copyright 2025 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Iterable
+import pathlib
+from typing import Optional
+
+from asn1crypto.algos import DSASignature
+from asn1crypto.core import OctetString
+from asn1crypto.keys import ECDomainParameters
+from asn1crypto.keys import PublicKeyInfo
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from google.protobuf import json_format
+import PyKCS11
+from sigstore_protobuf_specs.dev.sigstore.bundle import v1 as bundle_pb
+from sigstore_protobuf_specs.dev.sigstore.common import v1 as common_pb
+from sigstore_protobuf_specs.io import intoto as intoto_pb
+from typing_extensions import override
+
+from model_signing._signing import sign_ec_key as ec_key
+from model_signing._signing import sign_sigstore_pb as sigstore_pb
+from model_signing._signing import signing
+from model_signing._signing.pkcs11uri import Pkcs11URI
+
+
+MODULE_PATHS: Iterable[str] = [
+    "/usr/lib64/pkcs11/",  # Fedora, RHEL, openSUSE
+    "/usr/lib/pkcs11/",  # Fedora 32 bit, ArchLinux
+]
+
+
+def _check_supported_ec_key(public_key: ec.EllipticCurvePublicKey):
+    """Checks if the elliptic curve key is supported by our package.
+
+    We only support a family of curves, trying to match those specified by
+    Sigstore's protobuf specs.
+    See https://github.com/sigstore/model-transparency/issues/385.
+
+    Args:
+        public_key: The public key to check. Can be obtained from a private key.
+
+    Raises:
+        ValueError: The key is not supported.
+    """
+    curve = public_key.curve.name
+    if curve not in ["secp256r1", "secp384r1", "secp521r1"]:
+        raise ValueError(f"Unsupported key for curve '{curve}'")
+
+
+def encode_ec_public_key(public_key: PyKCS11.CK_OBJECT_HANDLE) -> PublicKeyInfo:
+    obj_d = public_key.to_dict()
+    return PublicKeyInfo(
+        {
+            "algorithm": {
+                "algorithm": "ec",
+                "parameters": ECDomainParameters.load(
+                    bytes(obj_d["CKA_EC_PARAMS"])
+                ),
+            },
+            "public_key": bytes(OctetString.load(bytes(obj_d["CKA_EC_POINT"]))),
+        }
+    ).dump()
+
+
+class Signer(sigstore_pb.Signer):
+    """Signer using PKCS #11 URIs with elliptic curves keys."""
+
+    def __init__(
+        self, pkcs11_uri: str, module_paths: Iterable[str] = frozenset()
+    ):
+        self.session = None
+
+        self.pkcs11_uri = Pkcs11URI()
+        self.pkcs11_uri.parse(pkcs11_uri)
+
+        if len(list(module_paths)) == 0:
+            module_paths = MODULE_PATHS
+
+        # To support module-name set a few standard paths
+        self.pkcs11_uri.set_module_directories(module_paths)
+        self.pkcs11_uri.set_allow_any_module(True)
+
+        self.session, self.lib = self.pkcs11_uri.login()
+
+        keyid, label = self.pkcs11_uri.get_keyid_and_label()
+
+        self._private_key = self.find_object(
+            PyKCS11.CKO_PRIVATE_KEY, label=label, id=keyid
+        )
+        public_key = self.find_object(
+            PyKCS11.CKO_PUBLIC_KEY, label=label, id=keyid
+        )
+        pub_der = encode_ec_public_key(public_key)
+
+        # _public_key is a python cryptography key now
+        self._public_key = serialization.load_der_public_key(pub_der)
+        _check_supported_ec_key(self._public_key)
+
+    def __del__(self):
+        if self.session:
+            try:
+                self.session.closeSession()
+            finally:
+                pass
+
+    def public_key(self):
+        """Get the python cryptography public key."""
+        return self._public_key
+
+    def find_object(
+        self, clas: int, label: Optional[str], id: Optional[bytes]
+    ) -> PyKCS11.CK_OBJECT_HANDLE:
+        """Find an object given its class and optional label and id."""
+        if label is None and id is None:
+            raise ValueError(
+                "Missing search criteria for object: either label or id must "
+                "be provided in URI"
+            )
+
+        msg = ""
+        if label is not None:
+            msg = f"label {label}"
+        if id is not None:
+            if len(msg):
+                msg += " and "
+            msg += f"id {id}"
+
+        cka_id = None
+        if id is not None:
+            cka_id = tuple([x for x in id])
+
+        for obj in self.session.findObjects([(PyKCS11.CKA_CLASS, clas)]):
+            obj_d = obj.to_dict()
+            if label is not None and label != obj_d.get("CKA_LABEL"):
+                continue
+            if cka_id is not None and cka_id != obj_d.get("CKA_ID"):
+                continue
+            return obj
+        raise ValueError(f"Could not find any object with {msg}")
+
+    @override
+    def sign(self, payload: signing.Payload) -> signing.Signature:
+        raw_payload = json_format.MessageToJson(payload.statement.pb).encode(
+            "utf-8"
+        )
+
+        hash_alg = ec_key.get_ec_key_hash(self._public_key)
+
+        hash = hashes.Hash(hash_alg)
+        hash.update(sigstore_pb.pae(raw_payload))
+        digest = hash.finalize()
+
+        rs_sig = self.session.sign(
+            self._private_key,
+            digest,
+            mecha=PyKCS11.Mechanism(PyKCS11.CKM_ECDSA, None),
+        )
+        # Convert plain r & s signature values to ASN.1
+        sig = DSASignature.from_p1363(rs_sig).dump()
+
+        raw_signature = intoto_pb.Signature(sig=sig, keyid=None)
+
+        envelope = intoto_pb.Envelope(
+            payload=raw_payload,
+            payload_type=signing._IN_TOTO_JSON_PAYLOAD_TYPE,
+            signatures=[raw_signature],
+        )
+
+        return sigstore_pb.Signature(
+            bundle_pb.Bundle(
+                media_type=sigstore_pb._BUNDLE_MEDIA_TYPE,
+                verification_material=self._get_verification_material(),
+                dsse_envelope=envelope,
+            )
+        )
+
+    def _get_verification_material(self) -> bundle_pb.VerificationMaterial:
+        """Returns the verification material to include in the bundle."""
+        public_key = self._public_key
+        key_size = public_key.curve.key_size
+
+        # TODO: Once Python 3.9 support is deprecated revert to using `match`
+        if key_size == 256:
+            key_details = common_pb.PublicKeyDetails.PKIX_ECDSA_P256_SHA_256
+        elif key_size == 384:
+            key_details = common_pb.PublicKeyDetails.PKIX_ECDSA_P384_SHA_384
+        elif key_size == 521:
+            key_details = common_pb.PublicKeyDetails.PKIX_ECDSA_P521_SHA_512
+        else:
+            raise ValueError(f"Unexpected key size {key_size}")
+
+        return bundle_pb.VerificationMaterial(
+            public_key=common_pb.PublicKey(
+                raw_bytes=public_key.public_bytes(
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+                ),
+                key_details=key_details,
+            )
+        )
+
+
+class CertSigner(Signer):
+    """Signer using certificates."""
+
+    def __init__(
+        self,
+        pkcs11_uri: str,
+        signing_certificate_path: pathlib.Path,
+        certificate_chain_paths: Iterable[pathlib.Path],
+        module_paths: Iterable[str] = frozenset(),
+    ):
+        """Initializes the signer with the key, certificate and trust chain.
+
+        Args:
+            pkcs11_uri: The PKCS #11 URI.
+            signing_certificate_path: The path to the signing certificate.
+            certificate_chain_paths: Paths to other certificates used to
+              establish chain of trust.
+
+        Raises:
+            ValueError: Signing certificate's public key does not match the
+              private key's public pair.
+        """
+        super().__init__(pkcs11_uri, module_paths=module_paths)
+        self._signing_certificate = x509.load_pem_x509_certificate(
+            signing_certificate_path.read_bytes()
+        )
+
+        public_key_from_key = self._public_key
+        public_key_from_certificate = self._signing_certificate.public_key()
+        if public_key_from_key != public_key_from_certificate:
+            raise ValueError(
+                "The public key from the certificate does not match "
+                "the public key paired with the private key"
+            )
+
+        self._trust_chain = x509.load_pem_x509_certificates(
+            b"".join([path.read_bytes() for path in certificate_chain_paths])
+        )
+
+    @override
+    def _get_verification_material(self) -> bundle_pb.VerificationMaterial:
+        def _to_protobuf_certificate(certificate):
+            return common_pb.X509Certificate(
+                raw_bytes=certificate.public_bytes(
+                    encoding=serialization.Encoding.DER
+                )
+            )
+
+        chain = [_to_protobuf_certificate(self._signing_certificate)]
+        chain.extend(
+            [
+                _to_protobuf_certificate(certificate)
+                for certificate in self._trust_chain
+            ]
+        )
+
+        return bundle_pb.VerificationMaterial(
+            x509_certificate_chain=common_pb.X509CertificateChain(
+                certificates=chain
+            )
+        )

--- a/src/model_signing/signing.py
+++ b/src/model_signing/signing.py
@@ -50,6 +50,7 @@ from typing import Optional
 from model_signing import hashing
 from model_signing._signing import sign_certificate as certificate
 from model_signing._signing import sign_ec_key as ec_key
+from model_signing._signing import sign_pkcs11 as pkcs11
 from model_signing._signing import sign_sigstore as sigstore
 from model_signing._signing import signing
 
@@ -194,5 +195,54 @@ class Config:
             pathlib.Path(private_key),
             pathlib.Path(signing_certificate),
             [pathlib.Path(c) for c in certificate_chain],
+        )
+        return self
+
+    def use_pkcs11_signer(
+        self, *, pkcs11_uri: str, module_paths: Iterable[str] = frozenset()
+    ) -> Self:
+        """Configures the signing to be performed using PKCS #11.
+
+        The signer in this configuration is changed to one that performs signing
+        using a private key based on elliptic curve cryptography.
+
+        Args:
+            pkcs11_uri: The PKCS11 URI.
+            module_paths: Optional list of paths of PKCS #11 modules.
+
+        Return:
+            The new signing configuration.
+        """
+        self._signer = pkcs11.Signer(pkcs11_uri, module_paths)
+        return self
+
+    def use_pkcs11_certificate_signer(
+        self,
+        *,
+        pkcs11_uri: str,
+        signing_certificate: pathlib.Path,
+        certificate_chain: Iterable[pathlib.Path],
+        module_paths: Iterable[str] = frozenset(),
+    ) -> Self:
+        """Configures the signing to be performed using signing certificates.
+
+        The signer in this configuration is changed to one that performs signing
+        using cryptographic certificates.
+
+        Args:
+            pkcs11_uri: The PKCS #11 URI.
+            signing_certificate: The path to the signing certificate.
+            certificate_chain: Optional paths to other certificates to establish
+              a chain of trust.
+            module_paths: Optional list of paths of PKCS #11 modules.
+
+        Return:
+            The new signing configuration.
+        """
+        self._signer = pkcs11.CertSigner(
+            pkcs11_uri,
+            signing_certificate,
+            certificate_chain,
+            module_paths=module_paths,
         )
         return self

--- a/tests/_signing/pkcs11uri_test.py
+++ b/tests/_signing/pkcs11uri_test.py
@@ -1,0 +1,267 @@
+# Copyright (c) 2025, IBM CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+import shutil
+import sys
+
+import pytest
+
+from model_signing._signing.pkcs11uri import Pkcs11URI
+from model_signing._signing.pkcs11uri import escape
+
+
+MODULE_PATHS = [
+    "/usr/lib64/pkcs11/",  # Fedora, RHEL, openSUSE
+    "/usr/lib/pkcs11/",  # Fedora 32 bit, ArchLinux
+    "/usr/lib/softhsm/",  # Ubuntu, Debian, Alpine
+]
+
+
+class TestPkcs11URI:
+    def verify_uri(self, uri: Pkcs11URI, expecteduri: str) -> None:
+        encoded = uri.format()
+        assert encoded == expecteduri
+
+    def verify_pin(self, uri: Pkcs11URI, expectedpin: str) -> None:
+        assert uri.has_pin()
+        pin = uri.get_pin()
+        assert pin == expectedpin
+
+    def _test_construct(self, uri: Pkcs11URI, expecteduri: str) -> None:
+        self.verify_uri(uri, expecteduri)
+
+        expectedpin = "the pin"
+        expecteduri += "?pin-value=the%20pin"
+
+        uri.add_query_attribute("pin-value", "the%20pin")
+
+        self.verify_uri(uri, expecteduri)
+        self.verify_pin(uri, expectedpin)
+
+        uri.remove_query_attribute("pin-value")
+        uri.add_query_attribute_unencoded(
+            "pin-value", expectedpin.encode("utf-8")
+        )
+
+        self.verify_uri(uri, expecteduri)
+        self.verify_pin(uri, expectedpin)
+
+    def test_construct1(self) -> None:
+        uri = Pkcs11URI()
+
+        uri.add_path_attribute("id", "%66oo")
+        self._test_construct(uri, "pkcs11:id=%66%6F%6F")
+
+    def test_construct2(self) -> None:
+        uri = Pkcs11URI()
+
+        uri.add_path_attribute_unencoded("id", b"\x66\x6f\x6f")
+        self._test_construct(uri, "pkcs11:id=%66%6F%6F")
+
+    def test_construct3(self) -> None:
+        uri = Pkcs11URI()
+
+        uri.add_path_attribute("slot-id", "12345")
+        self._test_construct(uri, "pkcs11:slot-id=12345")
+
+    def test_construct4(self) -> None:
+        uri = Pkcs11URI()
+
+        uri.add_path_attribute_unencoded("slot-id", b"12345")
+        self._test_construct(uri, "pkcs11:slot-id=12345")
+
+    def test_pin_source(self, tmp_path: pathlib.Path) -> None:
+        uri = Pkcs11URI()
+
+        expectedpin = "4321"
+
+        tmpfile = tmp_path.joinpath("pinfile")
+        tmpfile.write_bytes(expectedpin.encode("utf-8"))
+
+        # Need to escape paths for Windows
+        expecteduri = "pkcs11:id=%66%6F%6F?pin-source=file:" + escape(
+            str(tmpfile), False
+        )
+        uri.add_path_attribute("id", "foo")
+        uri.add_query_attribute("pin-source", "file:" + str(tmpfile), True)
+
+        self.verify_uri(uri, expecteduri)
+        self.verify_pin(uri, expectedpin)
+
+        if sys.platform in ["Linux", "darwin"]:
+            expecteduri = "pkcs11:id=%66%6F%6F?pin-source=" + escape(
+                str(tmpfile), False
+            )
+            uri.remove_query_attribute("pin-source")
+            uri.add_query_attribute("pin-source", str(tmpfile), True)
+
+            self.verify_uri(uri, expecteduri)
+            self.verify_pin(uri, expectedpin)
+
+    def test_bad_input(self) -> None:
+        uri = Pkcs11URI()
+
+        for entry in [
+            ("slot-id", "foo", "slot-id must be a number"),
+            (
+                "library-version",
+                "foo",
+                "Invalid format for library-version 'foo'",
+            ),
+            (
+                "library-version",
+                "1.bar",
+                "Invalid format for library-version '1.bar'",
+            ),
+            ("type", "foobar", "Invalid type 'foobar'"),
+        ]:
+            uri.add_path_attribute(entry[0], entry[1])
+            with pytest.raises(ValueError, match=entry[2]):
+                uri.validate()
+            uri.remove_path_attribute(entry[0])
+
+    def test_good_input(self) -> None:
+        uri = Pkcs11URI()
+
+        for entry in [
+            ("slot-id", "1"),
+            ("library-version", "7"),
+            ("library-version", "1.8"),
+            ("type", "public"),
+        ]:
+            uri.add_path_attribute(entry[0], entry[1])
+            uri.validate()
+            uri.remove_path_attribute(entry[0])
+
+    def test_uris(self) -> None:
+        uri = Pkcs11URI()
+
+        for uristring in [
+            "pkcs11:",
+            "pkcs11:object=my-pubkey;type=public",
+            "pkcs11:object=my-key;type=private?pin-source=file:/etc/token",
+            "pkcs11:token=The%20Software%20PKCS%2311%20Softtoken;manufacturer=Snake%20Oil,%20Inc.;model=1.0;object=my-certificate;type=cert;id=%69%95%3E%5C%F4%BD%EC%91;serial=?pin-source=file:/etc/token_pin",
+            "pkcs11:object=my-sign-key;type=private?module-name=mypkcs11",
+            "pkcs11:object=my-sign-key;type=private?module-path=/mnt/libmypkcs11.so.1",
+            "pkcs11:token=Software%20PKCS%2311%20softtoken;manufacturer=Snake%20Oil,%20Inc.?pin-value=the-pin",
+            "pkcs11:slot-description=Sun%20Metaslot",
+            "pkcs11:library-manufacturer=Snake%20Oil,%20Inc.;library-description=Soft%20Token%20Library;library-version=1.23",
+            "pkcs11:token=My%20token%25%20created%20by%20Joe;library-version=3;id=%01%02%03%Ba%dd%Ca%fe%04%05%06",
+            "pkcs11:token=A%20name%20with%20a%20substring%20%25%3B;object=my-certificate;type=cert",
+            "pkcs11:token=Name%20with%20a%20small%20A%20with%20acute:%20%C3%A1;object=my-certificate;type=cert",
+            "pkcs11:token=my-token;object=my-certificate;type=cert;vendor-aaa=value-a?pin-source=file:/etc/token_pin&vendor-bbb=value-b",
+        ]:
+            # Skip test with an absolute module-path that is not accepted on
+            # Windows
+            if uristring.find("module-path=/") >= 0 and sys.platform not in [
+                "linux",
+                "darwin",
+            ]:
+                continue
+            uri.parse(uristring)
+            encoded = uri.format()
+            assert len(encoded) == len(uristring)
+
+    def test_validate_escaped_attrs(self) -> None:
+        uri = Pkcs11URI()
+
+        for input in [
+            {
+                "uri": "pkcs11:token=Software%20PKCS%2311%20softtoken;manufacturer=Snake%20Oil,%20Inc.?pin-value=the-pin",  # noqa
+                "testp": [
+                    "token",
+                    "Software PKCS#11 softtoken",
+                    "Software%20PKCS%2311%20softtoken",
+                ],
+                "format": False,
+            },
+            {
+                "uri": "pkcs11:token=My%20token%25%20created%20by%20Joe;library-version=3;id=%01%02%03%Ba%dd%Ca%fe%04%05%06",  # noqa
+                "testp": [
+                    "token",
+                    "My token% created by Joe",
+                    "My%20token%25%20created%20by%20Joe",
+                ],
+                "format": False,
+            },
+            {
+                # test pk11-query-res-avail and pk11-path-res-avail special
+                # characters
+                "uri": "pkcs11:token=:[]@!$'()*+,=&?attr=:[]@!$'()*+,=/?",
+                "testp": ["token", ":[]@!$'()*+,=&", ":[]@!$'()*+,=&"],
+                "testq": ["attr", ":[]@!$'()*+,=/?", ":[]@!$'()*+,=/?"],
+                "format": True,
+            },
+            {
+                # test (some) unnecessarily escaped characters
+                "uri": "pkcs11:token=%3a%5b%5d%40%21%24%27%28%29%2a%2b%2c%26%3d-%60%20%3c%3e%7b",  # noqa
+                "testp": [
+                    "token",
+                    ":[]@!$'()*+,&=-` <>{",
+                    ":[]@!$'()*+,&=-%60%20%3C%3E%7B",
+                ],
+                "format": False,
+            },
+            {
+                # test some non-printable characters that have to be escape;
+                "uri": "pkcs11:token=%00%01%02Hello%FF%FE",
+                "testp": [
+                    "token",
+                    "\x00\x01\x02Hello\xff\xfe",
+                    "%00%01%02Hello%FF%FE",
+                ],
+                "format": True,
+            },
+        ]:
+            uri.parse(input["uri"])
+            v = uri.get_path_attribute(input["testp"][0], False)
+            assert v == input["testp"][1]
+            v = uri.get_path_attribute(input["testp"][0], True)
+            assert v == input["testp"][2]
+
+            if input.get("testq"):
+                v = uri.get_query_attribute(input["testq"][0], False)
+                assert v == input["testq"][1]
+                v = uri.get_query_attribute(input["testq"][0], True)
+                assert v == input["testq"][2]
+
+            if input["format"]:
+                assert input["uri"] == uri.format()
+
+    def test_get_module(self) -> None:
+        uri = Pkcs11URI()
+        uri.set_module_directories(MODULE_PATHS)
+        uri.set_allow_any_module(True)
+
+        uristring = "pkcs11:?module-name=softhsm2"
+        uri.parse(uristring)
+        if shutil.which("softhsm2-util") is not None:
+            uri.get_module()
+
+    def test_get_module_restricted(self) -> None:
+        uri = Pkcs11URI()
+        uri.set_module_directories(MODULE_PATHS)
+        uri.set_allow_any_module(False)
+
+        uristring = "pkcs11:?module-name=softhsm2"
+        uri.parse(uristring)
+
+        if shutil.which("softhsm2-util") is not None:
+            uri.set_allowed_module_paths(["/usr"])
+            with pytest.raises(ValueError, match=".*is not allowed by policy$"):
+                uri.get_module()
+
+            uri.set_allowed_module_paths(MODULE_PATHS)
+            uri.get_module()


### PR DESCRIPTION
#### Summary

This PR enables signing with PKCS  #11 devices, such as HSMs, using RFC 7512 compliant PKCS #11 URIs. The signing piggy-backs on the existing signing methods for 'key` and 'certificate' where the --private_key option now accepts a PKCS #11 URI. For signature verification it is expected that one has the public key in PEM format or root certificate(s) available to use existing signature verification methods.

A test case with SoftHSM is provided. I have also successfully tested it with TPM 2 and another service.

I extended the documentation for this new method as well.
