### PR TITLE
Simplify ignoring git paths

### DIFF
--- a/src/model_signing/_cli.py
+++ b/src/model_signing/_cli.py
@@ -218,7 +218,7 @@ def _sign_sigstore(
             identity_token=identity_token,
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                ignore_paths, ignore_git_paths
+                paths=ignore_paths, ignore_git_paths=ignore_git_paths
             )
         ).sign(model_path, signature)
     except Exception as err:
@@ -265,7 +265,7 @@ def _sign_private_key(
             private_key=private_key, password=password
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                ignore_paths, ignore_git_paths
+                paths=ignore_paths, ignore_git_paths=ignore_git_paths
             )
         ).sign(model_path, signature)
     except Exception as err:
@@ -320,7 +320,7 @@ def _sign_certificate(
             certificate_chain=certificate_chain,
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                ignore_paths, ignore_git_paths
+                paths=ignore_paths, ignore_git_paths=ignore_git_paths
             )
         ).sign(model_path, signature)
     except Exception as err:
@@ -392,7 +392,7 @@ def _verify_sigstore(
             use_staging=use_staging,
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                ignore_paths, ignore_git_paths
+                paths=ignore_paths, ignore_git_paths=ignore_git_paths
             )
         ).verify(model_path, signature)
     except Exception as err:
@@ -438,7 +438,7 @@ def _verify_private_key(
             public_key=public_key
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                ignore_paths, ignore_git_paths
+                paths=ignore_paths, ignore_git_paths=ignore_git_paths
             )
         ).verify(model_path, signature)
     except Exception as err:
@@ -478,7 +478,7 @@ def _verify_certificate(
             certificate_chain=certificate_chain
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                ignore_paths, ignore_git_paths
+                paths=ignore_paths, ignore_git_paths=ignore_git_paths
             )
         ).verify(model_path, signature)
     except Exception as err:

--- a/src/model_signing/_cli.py
+++ b/src/model_signing/_cli.py
@@ -97,25 +97,6 @@ _sigstore_staging_option = click.option(
 )
 
 
-def _collect_git_related_files(model_path: pathlib.Path) -> list[pathlib.Path]:
-    """Expand to all git related files in the model directory."""
-    return [pathlib.Path(p) for p in list(model_path.glob("**/.git*"))]
-
-
-def _expand_paths_to_ignore(
-    model_path: pathlib.Path,
-    signature: pathlib.Path,
-    ignore_paths: Iterable[pathlib.Path],
-    ignore_git_paths: bool,
-) -> list[pathlib.Path]:
-    """Expand all ignore arguments to build the list of paths to exclude."""
-    ignore_paths = [path for path in ignore_paths]
-    ignore_paths.append(signature)
-    if ignore_git_paths:
-        ignore_paths.extend(_collect_git_related_files(model_path))
-    return ignore_paths
-
-
 class PKICmdGroup(click.Group):
     """A custom group to configure the supported PKI methods."""
 
@@ -237,9 +218,7 @@ def _sign_sigstore(
             identity_token=identity_token,
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                _expand_paths_to_ignore(
-                    model_path, signature, ignore_paths, ignore_git_paths
-                )
+                ignore_paths, ignore_git_paths
             )
         ).sign(model_path, signature)
     except Exception as err:
@@ -286,9 +265,7 @@ def _sign_private_key(
             private_key=private_key, password=password
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                _expand_paths_to_ignore(
-                    model_path, signature, ignore_paths, ignore_git_paths
-                )
+                ignore_paths, ignore_git_paths
             )
         ).sign(model_path, signature)
     except Exception as err:
@@ -343,9 +320,7 @@ def _sign_certificate(
             certificate_chain=certificate_chain,
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                _expand_paths_to_ignore(
-                    model_path, signature, ignore_paths, ignore_git_paths
-                )
+                ignore_paths, ignore_git_paths
             )
         ).sign(model_path, signature)
     except Exception as err:
@@ -417,9 +392,7 @@ def _verify_sigstore(
             use_staging=use_staging,
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                _expand_paths_to_ignore(
-                    model_path, signature, ignore_paths, ignore_git_paths
-                )
+                ignore_paths, ignore_git_paths
             )
         ).verify(model_path, signature)
     except Exception as err:
@@ -465,9 +438,7 @@ def _verify_private_key(
             public_key=public_key
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                _expand_paths_to_ignore(
-                    model_path, signature, ignore_paths, ignore_git_paths
-                )
+                ignore_paths, ignore_git_paths
             )
         ).verify(model_path, signature)
     except Exception as err:
@@ -507,9 +478,7 @@ def _verify_certificate(
             certificate_chain=certificate_chain
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                _expand_paths_to_ignore(
-                    model_path, signature, ignore_paths, ignore_git_paths
-                )
+                ignore_paths, ignore_git_paths
             )
         ).verify(model_path, signature)
     except Exception as err:

--- a/src/model_signing/hashing.py
+++ b/src/model_signing/hashing.py
@@ -56,7 +56,7 @@ def hash(model_path: os.PathLike) -> manifest.Manifest:
     depends on the configuration.
 
     Args:
-        model_path: the path to the model to hash.
+        model_path: The path to the model to hash.
 
     Returns:
         A manifest of the hashed model.
@@ -90,12 +90,17 @@ class Config:
         symbolic link in the model directory results in an error.
         """
         self._ignored_paths = frozenset()
+        self._ignore_git_paths = True
         self.use_file_serialization()
 
     def hash(self, model_path: os.PathLike) -> manifest.Manifest:
         """Hashes a model using the current configuration."""
+        ignored_paths = [path for path in self._ignored_paths]
+        if self._ignore_git_paths:
+            ignored_paths.extend([path for path in model_path.glob("**/.git*")])
+
         return self._serializer.serialize(
-            pathlib.Path(model_path), ignore_paths=self._ignored_paths
+            pathlib.Path(model_path), ignore_paths=ignored_paths
         )
 
     def _build_stream_hasher(
@@ -104,7 +109,7 @@ class Config:
         """Builds a streaming hasher from a constant string.
 
         Args:
-            hashing_algorithm: the hashing algorithm to use.
+            hashing_algorithm: The hashing algorithm to use.
 
         Returns:
             An instance of the requested hasher.
@@ -125,7 +130,7 @@ class Config:
         """Builds the hasher factory for a serialization by file.
 
         Args:
-            hashing_algorithm: the hashing algorithm to use to hash a file
+            hashing_algorithm: The hashing algorithm to use to hash a file.
             chunk_size: The amount of file to read at once. Default is 1MB. A
               special value of 0 signals to attempt to read everything in a
               single call.
@@ -150,7 +155,7 @@ class Config:
         """Builds the hasher factory for a serialization by file shards.
 
         Args:
-            hashing_algorithm: the hashing algorithm to use to hash a file
+            hashing_algorithm: The hashing algorithm to use to hash a shard.
             chunk_size: The amount of file to read at once. Default is 1MB. A
               special value of 0 signals to attempt to read everything in a
               single call.
@@ -191,7 +196,7 @@ class Config:
         containing all these pairings is being returned.
 
         Args:
-            hashing_algorithm: the hashing algorithm to use to hash a file
+            hashing_algorithm: The hashing algorithm to use to hash a file.
             chunk_size: The amount of file to read at once. Default is 1MB. A
               special value of 0 signals to attempt to read everything in a
               single call.
@@ -228,7 +233,7 @@ class Config:
         is being returned.
 
         Args:
-            hashing_algorithm: the hashing algorithm to use to hash a file shard
+            hashing_algorithm: The hashing algorithm to use to hash a shard.
             chunk_size: The amount of file to read at once. Default is 1MB. A
               special value of 0 signals to attempt to read everything in a
               single call.
@@ -251,7 +256,9 @@ class Config:
         )
         return self
 
-    def set_ignored_paths(self, paths: Iterable[os.PathLike]) -> Self:
+    def set_ignored_paths(
+        self, *, paths: Iterable[os.PathLike], ignore_git_paths: bool = True
+    ) -> Self:
         """Configures the paths to be ignored during serialization of a model.
 
         If the model is a single file, there are no paths that are ignored. If
@@ -264,10 +271,13 @@ class Config:
         any of its children.
 
         Args:
-            paths: the paths to ignore
+            paths: The paths to ignore.
+            ignore_git_paths: Whether to ignore git related paths (default) or
+              include them in the signature.
 
         Returns:
             The new hashing configuration with a new set of ignored paths.
         """
         self._ignored_paths = frozenset({pathlib.Path(p) for p in paths})
+        self._ignore_git_paths = ignore_git_paths
         return self

--- a/src/model_signing/hashing.py
+++ b/src/model_signing/hashing.py
@@ -97,7 +97,9 @@ class Config:
         """Hashes a model using the current configuration."""
         ignored_paths = [path for path in self._ignored_paths]
         if self._ignore_git_paths:
-            ignored_paths.append(".git/")
+            ignored_paths.extend(
+                [".git/", ".gitattributes", ".github/", ".gitignore"]
+            )
 
         return self._serializer.serialize(
             pathlib.Path(model_path), ignore_paths=ignored_paths

--- a/src/model_signing/hashing.py
+++ b/src/model_signing/hashing.py
@@ -97,7 +97,7 @@ class Config:
         """Hashes a model using the current configuration."""
         ignored_paths = [path for path in self._ignored_paths]
         if self._ignore_git_paths:
-            ignored_paths.extend([path for path in model_path.glob("**/.git*")])
+            ignored_paths.append(".git/")
 
         return self._serializer.serialize(
             pathlib.Path(model_path), ignore_paths=ignored_paths


### PR DESCRIPTION
#### Summary
First, move the ignoring of paths into the API, so that the CLI code is a little bit simpler.

Then, realize that we already exclude paths if they are relative to a path in the ignore list, so we only need to add `.git` to exclude.

#### Release Note
NONE

#### Documentation
NONE