### PR TITLE
Don't use ambient credentials by default.

### DIFF
--- a/src/model_signing/signing.py
+++ b/src/model_signing/signing.py
@@ -91,7 +91,7 @@ class Config:
         self,
         *,
         oidc_issuer: Optional[str] = None,
-        use_ambient_credentials: bool = True,
+        use_ambient_credentials: bool = False,
         use_staging: bool = False,
         identity_token: Optional[str] = None,
     ) -> Self:
@@ -105,9 +105,9 @@ class Config:
               default production one. Only relevant if `use_staging = False`.
               Default is empty, relying on the Sigstore configuration.
             use_ambient_credentials: Use ambient credentials (also known as
-              Workload Identity). Default is True. If ambient credentials cannot
-              be used (not available, or option disabled), a flow to get signer
-              identity via OIDC will start.
+              Workload Identity). Default is False. If ambient credentials
+              cannot be used (not available, or option disabled), a flow to get
+              signer identity via OIDC will start.
             use_staging: Use staging configurations, instead of production. This
               is supposed to be set to True only when testing. Default is False.
             identity_token: An explicit identity token to use when signing,


### PR DESCRIPTION
#### Summary

If we try to and they don't exist (during manual testing), then we run into errors.

In colab I have the following error:

```
--------------------------------------------------------------------------
HTTPError                                 Traceback (most recent call last)
/usr/local/lib/python3.11/dist-packages/id/_internal/oidc/ambient.py in detect_gcp(audience)
    196         try:
--> 197             resp.raise_for_status()
    198         except requests.HTTPError as http_error:

10 frames
HTTPError: 404 Client Error: Not Found for url: http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=sigstore&format=full

The above exception was the direct cause of the following exception:

AmbientCredentialError                    Traceback (most recent call last)
AmbientCredentialError: GCP: OIDC token request failed (code=404, body='')

The above exception was the direct cause of the following exception:

IdentityError                             Traceback (most recent call last)
/usr/local/lib/python3.11/dist-packages/sigstore/oidc.py in raise_from_id(cls, exc)
    379     def raise_from_id(cls, exc: id.IdentityError) -> NoReturn:
    380         """Raises a wrapped IdentityError from the provided `id.IdentityError`."""
--> 381         raise cls(str(exc)) from exc
    382
    383     def diagnostics(self) -> str:

IdentityError: GCP: OIDC token request failed (code=404, body='')
```

#### Release Note
NONE

#### Documentation
NONE