### PR TITLE
fix: argument typo and type checking in certificate Verifier

### DIFF
--- a/src/model_signing/_signing/sign_certificate.py
+++ b/src/model_signing/_signing/sign_certificate.py
@@ -73,7 +73,7 @@ class Signer(ec_key.Signer):
     def _get_verification_material(self) -> bundle_pb.VerificationMaterial:
         def _to_protobuf_certificate(certificate):
             return common_pb.X509Certificate(
-                raw_byutes=certificate.public_bytes(
+                raw_bytes=certificate.public_bytes(
                     encoding=serialization.Encoding.DER
                 )
             )
@@ -108,7 +108,7 @@ class Verifier(sigstore_pb.Verifier):
               operating system, as per `certifi.where()`.
         """
         if not certificate_chain_paths:
-            certificate_chain_paths = [certifi.where()]
+            certificate_chain_paths = [pathlib.Path(p) for p in certifi.where()]
 
         certificates = x509.load_pem_x509_certificates(
             b"".join([path.read_bytes() for path in certificate_chain_paths])


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
fix typo in X509Certificate argument name.

certifi.where returns `list[str]` but we're expecting `Iterable[pathlib.Path]` here

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
NONE