### PR TITLE
Document the public API.

### DIFF
--- a/src/model_signing/__init__.py
+++ b/src/model_signing/__init__.py
@@ -14,14 +14,114 @@
 
 """Universal model signing library.
 
-The stable high-level API is split into 3 modules:
+The API is split into 3 main components (and a glue `model_signing.manifest`
+module for data types used in public interfaces):
 
-- model_signing.hashing
-- model_signing.signing
-- model_signing.verifying
+- `model_signing.hashing`: responsible with generating a list of hashes for
+  every component of the model. A component could be a file, a file shard, a
+  tensor, etc., depending on the method used. We currently support only files
+  and file shards. The result of hashing is a manifest, a listing of hashes for
+  every object in the model.
+- `model_signing.signing`: responsible with taking the manifest and generating a
+  signature, based on a signing configuration. The signing configuration can
+  select the method used to sign as well as the parameters.
+- `model_signing.verifying`: responsible with taking a signature and verifying
+  it. If the cryptographic parts of the signature can be validated, the
+  verification layer would return an expanded manifest which can then be
+  compared agains a manifest obtained from hashing the existing model. If the
+  two manifest don't match then the model integrity was compromised and the
+  `model_signing` package detected that.
+
+The first two of these components allows configurability but can also be used
+directly, with a default configuration. The only difference is for the
+verification component where we need to configure the verification method since
+there are no sensible defaults that can be used.
+
+Signing can be done using the default configuration:
+
+```python
+model_signing.signing.sign("finbert", "finbert.sig")
+```
+
+This example generates the signature using Sigstore.
+
+Alternatively, a custom configuration can be selected, for both signing and
+hashing:
+
+```python
+model_signing.signing.Config().use_elliptic_key_signer(
+    private_key="key"
+).set_hashing_config(
+    model_signing.hashing.Config().set_ignored_paths(
+        paths=["README.md"], ignore_git_paths=True
+    )
+).sign("finbert", "finbert.sig")
+```
+
+This example generates a signature using a private key based on elliptic curve
+cryptography. It also hashes the model by ignoring `README.md` and any git
+related file present in the model directory.
+
+We also support signing with signing certificates, using a similar API as above.
+
+When verifying, we need to configure the cryptography configuration, so that the
+code knows how to parse the signature.
+
+For the Sigstore example, the simplest verification example would be:
+
+```python
+model_signing.verifying.Config().use_sigstore_verifier(
+    identity=identity, oidc_issuer=oidc_provider
+).verify("finbert", "finbert.sig")
+```
+
+Where `identity` and `oidc_provider` are the parameters obtained after the OIDC
+flow during signing.
+
+To verify the private key example, we could use the following:
+
+```python
+model_signing.verifying.Config().use_elliptic_key_verifier(
+    public_key="key.pub"
+).set_hashing_config(
+    model_signing.hashing.Config().set_ignored_paths(
+        paths=["README.md"], ignore_git_paths=True
+    )
+).verify("finbert", "finbert.sig")
+```
+
+Alternatively, we also support automatic detection of the hashing configuration
+during the verification process. So, the following should also work:
+
+```python
+model_signing.verifying.Config().use_elliptic_key_verifier(
+    public_key="key.pub"
+).verify("finbert", "finbert.sig")
+```
+
+A reminder that we still need to set the verification configuration. This sets
+up the cryptographic primitives to verify the signature and is needed to know
+how to parse the signature file.
+
+For any signing method, the signature is a
+[Sigstore bundle](https://docs.sigstore.dev/about/bundle/) which contains the
+verification material (the information needed to verify the signature) and the
+payload. The verification material depends on the method used for signing.
+
+The payload in the signature is a
+[DSSE envelope](https://github.com/secure-systems-lab/dsse) which contains an
+[in-toto statement](https://github.com/in-toto/attestation/tree/main/spec/v1).
+The in-toto statement contains the actual metadata that gets signed, and in our
+case is a custom predicate that identifies all the components of the model.
+
+Read more [on the repository's `README.md`][repo]. The CLI that maps over the
+API is also documented there.
+
+[repo]: https://github.com/sigstore/model-transparency/blob/main/README.md
 """
 
 from model_signing import hashing
+from model_signing import manifest
 from model_signing import signing
 from model_signing import verifying
 
@@ -29,4 +129,4 @@ from model_signing import verifying
 __version__ = "0.3.1"
 
 
-__all__ = ["hashing", "signing", "verifying"]
+__all__ = ["hashing", "signing", "verifying", "manifest"]

--- a/src/model_signing/__init__.py
+++ b/src/model_signing/__init__.py
@@ -84,8 +84,7 @@ To verify the private key example, we could use the following:
 model_signing.verifying.Config().use_elliptic_key_verifier(
     public_key="key.pub"
 ).set_hashing_config(
-    model_signing.hashing.Config().set_ignored_paths(
-        paths=["README.md"], ignore_git_paths=True
+    model_signing.hashing.Config().use_shard_serialization()
     )
 ).verify("finbert", "finbert.sig")
 ```

--- a/src/model_signing/_cli.py
+++ b/src/model_signing/_cli.py
@@ -97,7 +97,7 @@ _sigstore_staging_option = click.option(
 )
 
 
-class PKICmdGroup(click.Group):
+class _PKICmdGroup(click.Group):
     """A custom group to configure the supported PKI methods."""
 
     _supported_modes = ["sigstore", "key", "certificate"]
@@ -150,7 +150,7 @@ def main() -> None:
     """
 
 
-@main.group(name="sign", subcommand_metavar="PKI_METHOD", cls=PKICmdGroup)
+@main.group(name="sign", subcommand_metavar="PKI_METHOD", cls=_PKICmdGroup)
 def _sign() -> None:
     """Sign models.
 
@@ -329,7 +329,7 @@ def _sign_certificate(
         click.echo("Signing succeeded")
 
 
-@main.group(name="verify", subcommand_metavar="PKI_METHOD", cls=PKICmdGroup)
+@main.group(name="verify", subcommand_metavar="PKI_METHOD", cls=_PKICmdGroup)
 def _verify() -> None:
     """Verify models.
 

--- a/src/model_signing/hashing.py
+++ b/src/model_signing/hashing.py
@@ -20,7 +20,7 @@ the same configuration is used in both cases.
 The module could also be used to just hash a single model, without signing it:
 
 ```python
-model_signing.hash(model_path)
+model_signing.hashing.hash(model_path)
 ```
 
 This module allows setting up the hashing configuration to a single variable and
@@ -251,7 +251,7 @@ class Config:
               single call.
             max_workers: Maximum number of workers to use in parallel. Default
               is to defer to the `concurrent.futures` library to select the best
-              value for the current operating system.
+              value for the current machine.
             allow_symlinks: Controls whether symbolic links are included. If a
               symlink is present but the flag is `False` (default) the
               serialization would raise an error.
@@ -290,7 +290,7 @@ class Config:
             shard_size: The size of a file shard. Default is 1 GB.
             max_workers: Maximum number of workers to use in parallel. Default
               is to defer to the `concurrent.futures` library to select the best
-              value for the current operating system.
+              value for the current machine.
             allow_symlinks: Controls whether symbolic links are included. If a
               symlink is present but the flag is `False` (default) the
               serialization would raise an error.

--- a/tests/_serialization/file_shard_test.py
+++ b/tests/_serialization/file_shard_test.py
@@ -34,7 +34,7 @@ from tests import test_support
 
 def _extract_shard_items_from_manifest(
     manifest: manifest.Manifest,
-) -> dict[manifest.ManifestKey, str]:
+) -> dict[manifest._ManifestKey, str]:
     """Builds a dictionary representation of the items in a manifest.
 
     Every item is mapped to its digest.
@@ -47,7 +47,7 @@ def _extract_shard_items_from_manifest(
     }
 
 
-def _parse_shard_and_digest(line: str) -> tuple[manifest.Shard, str]:
+def _parse_shard_and_digest(line: str) -> tuple[manifest._Shard, str]:
     """Reads a file shard and its digest from a line in the golden file.
 
     Args:
@@ -57,7 +57,7 @@ def _parse_shard_and_digest(line: str) -> tuple[manifest.Shard, str]:
         The shard tuple and the digest corresponding to the line that was read.
     """
     path, start, end, digest = line.strip().split(":")
-    shard = manifest.Shard(pathlib.PurePosixPath(path), int(start), int(end))
+    shard = manifest._Shard(pathlib.PurePosixPath(path), int(start), int(end))
     return shard, digest
 
 
@@ -97,7 +97,7 @@ class TestSerializer:
                 for shard, digest in sorted(items.items()):
                     f.write(f"{shard}:{digest}\n")
         else:
-            found_items: dict[manifest.Shard, str] = {}
+            found_items: dict[manifest._Shard, str] = {}
             with open(golden_path, "r", encoding="utf-8") as f:
                 for line in f:
                     shard, digest = _parse_shard_and_digest(line)
@@ -128,7 +128,7 @@ class TestSerializer:
                 for shard, digest in sorted(items.items()):
                     f.write(f"{shard}:{digest}\n")
         else:
-            found_items: dict[manifest.Shard, str] = {}
+            found_items: dict[manifest._Shard, str] = {}
             with open(golden_path, "r", encoding="utf-8") as f:
                 for line in f:
                     shard, digest = _parse_shard_and_digest(line)
@@ -224,9 +224,9 @@ class TestSerializer:
             old_manifest._item_to_digest
         )
         for key, digest in new_manifest._item_to_digest.items():
-            shard = cast(manifest.Shard, key)
+            shard = cast(manifest._Shard, key)
             if shard.path.name == new_name:
-                old_shard = manifest.Shard(old_name, shard.start, shard.end)
+                old_shard = manifest._Shard(old_name, shard.start, shard.end)
                 assert old_manifest._item_to_digest[old_shard] == digest
             else:
                 assert old_manifest._item_to_digest[shard] == digest
@@ -266,13 +266,13 @@ class TestSerializer:
             old_manifest._item_to_digest
         )
         for key, digest in new_manifest._item_to_digest.items():
-            shard = cast(manifest.Shard, key)
+            shard = cast(manifest._Shard, key)
             if new_name in shard.path.parts:
                 parts = [
                     old_name if part == new_name else part
                     for part in shard.path.parts
                 ]
-                old = manifest.Shard(
+                old = manifest._Shard(
                     pathlib.PurePosixPath(*parts), shard.start, shard.end
                 )
                 assert old_manifest._item_to_digest[old] == digest
@@ -325,10 +325,10 @@ class TestSerializer:
             old_manifest._item_to_digest
         )
         for key, digest in new_manifest._item_to_digest.items():
-            shard = cast(manifest.Shard, key)
+            shard = cast(manifest._Shard, key)
             if shard.path == expected_mismatch_path:
                 # Note that the file size changes
-                key = manifest.Shard(shard.path, 0, 23)
+                key = manifest._Shard(shard.path, 0, 23)
                 assert old_manifest._item_to_digest[key] != digest
             else:
                 assert old_manifest._item_to_digest[shard] == digest
@@ -369,7 +369,7 @@ class TestSerializer:
 
     def test_shard_to_string(self):
         """Ensure the shard's `__str__` method behaves as assumed."""
-        shard = manifest.Shard(pathlib.PurePosixPath("a"), 0, 42)
+        shard = manifest._Shard(pathlib.PurePosixPath("a"), 0, 42)
         assert str(shard) == "a:0:42"
 
     def test_ignore_list_respects_directories(self, sample_model_folder):

--- a/tests/_serialization/file_test.py
+++ b/tests/_serialization/file_test.py
@@ -161,11 +161,11 @@ class TestSerializer:
             old_manifest._item_to_digest
         )
         for key, digest in new_manifest._item_to_digest.items():
-            path = cast(manifest.File, key).path
+            path = cast(manifest._File, key).path
             if path.name == new_name:
-                key = manifest.File(old_name)
+                key = manifest._File(old_name)
             else:
-                key = manifest.File(path)
+                key = manifest._File(path)
             assert old_manifest._item_to_digest[key] == digest
 
     def test_folder_model_rename_file_only_changes_path_part(
@@ -203,17 +203,17 @@ class TestSerializer:
             old_manifest._item_to_digest
         )
         for key, digest in new_manifest._item_to_digest.items():
-            path = cast(manifest.File, key).path
+            path = cast(manifest._File, key).path
             if new_name in path.parts:
                 parts = [
                     old_name if part == new_name else part
                     for part in path.parts
                 ]
                 old = pathlib.PurePosixPath(*parts)
-                key = manifest.File(old)
+                key = manifest._File(old)
                 assert old_manifest._item_to_digest[key] == digest
             else:
-                key = manifest.File(path)
+                key = manifest._File(path)
                 assert old_manifest._item_to_digest[key] == digest
 
     def test_folder_model_rename_dir_only_changes_path_part(
@@ -262,7 +262,7 @@ class TestSerializer:
             old_manifest._item_to_digest
         )
         for key, digest in new_manifest._item_to_digest.items():
-            path = cast(manifest.File, key).path
+            path = cast(manifest._File, key).path
             if path == expected_mismatch_path:
                 assert old_manifest._item_to_digest[key] != digest
             else:

--- a/tests/manifest_test.py
+++ b/tests/manifest_test.py
@@ -81,38 +81,38 @@ class TestFileLevelManifest:
 
 class TestShard:
     def test_round_trip_from_shard(self):
-        shard = manifest.Shard(pathlib.PurePosixPath("file"), 0, 42)
+        shard = manifest._Shard(pathlib.PurePosixPath("file"), 0, 42)
         shard_str = str(shard)
-        assert manifest.Shard.from_str(shard_str) == shard
+        assert manifest._Shard.from_str(shard_str) == shard
 
     def test_round_trip_from_string(self):
         shard_str = "file:0:42"
-        shard = manifest.Shard.from_str(shard_str)
+        shard = manifest._Shard.from_str(shard_str)
         assert str(shard) == shard_str
 
     def test_invalid_shard_str_too_few_components(self):
         shard_str = "file"
 
         with pytest.raises(ValueError, match="Expected 3 components"):
-            manifest.Shard.from_str(shard_str)
+            manifest._Shard.from_str(shard_str)
 
     def test_invalid_shard_str_too_many_components(self):
         shard_str = "file:0:1:2"
 
         with pytest.raises(ValueError, match="Expected 3 components"):
-            manifest.Shard.from_str(shard_str)
+            manifest._Shard.from_str(shard_str)
 
     def test_invalid_shard_bad_type_for_start_offset(self):
         shard_str = "file:zero:4"
 
         with pytest.raises(ValueError, match="invalid literal for int"):
-            manifest.Shard.from_str(shard_str)
+            manifest._Shard.from_str(shard_str)
 
     def test_invalid_shard_bad_type_for_endart_offset(self):
         shard_str = "file:0:four"
 
         with pytest.raises(ValueError, match="invalid literal for int"):
-            manifest.Shard.from_str(shard_str)
+            manifest._Shard.from_str(shard_str)
 
 
 class TestShardLevelManifest:


### PR DESCRIPTION
#### Summary
We have to expose the manifest file, but I tried to hide parts that should not be exposed externally. We don't guarantee the manifest interface to be fully stable, so this should be ok?

As a drive-by, I made the CLI code only have one single public symbol.

Part of #179.

#### Release Note
NONE
#### Documentation
NONE