### PR TITLE
Use the content hasher name for serialization type

### DIFF
--- a/src/model_signing/_serialization/file_shard.py
+++ b/src/model_signing/_serialization/file_shard.py
@@ -88,7 +88,11 @@ class Serializer(serialization.Serializer):
         hasher = sharded_hasher_factory(pathlib.Path(), 0, 1)
         self._shard_size = hasher.shard_size
         self._serialization_description = manifest._ShardSerialization(
-            hasher.digest_name, self._shard_size, self._allow_symlinks
+            # Here we need the internal hasher name, not the mangled name.
+            # This name is used when guessing the hashing configuration.
+            hasher._content_hasher.digest_name,
+            self._shard_size,
+            self._allow_symlinks,
         )
 
     @override

--- a/tests/_signing/testdata/signing/TestPayload/deep_model_folder_shard
+++ b/tests/_signing/testdata/signing/TestPayload/deep_model_folder_shard
@@ -12,7 +12,7 @@
   "predicate": {
     "serialization": {
       "method": "shards",
-      "hash_type": "sha256-sharded-1000000000",
+      "hash_type": "sha256",
       "allow_symlinks": true,
       "shard_size": 1000000000.0
     },

--- a/tests/_signing/testdata/signing/TestPayload/deep_model_folder_small_shards
+++ b/tests/_signing/testdata/signing/TestPayload/deep_model_folder_small_shards
@@ -12,7 +12,7 @@
   "predicate": {
     "serialization": {
       "method": "shards",
-      "hash_type": "sha256-sharded-8",
+      "hash_type": "sha256",
       "allow_symlinks": true,
       "shard_size": 8.0
     },

--- a/tests/_signing/testdata/signing/TestPayload/empty_model_file_shard
+++ b/tests/_signing/testdata/signing/TestPayload/empty_model_file_shard
@@ -12,7 +12,7 @@
   "predicate": {
     "serialization": {
       "method": "shards",
-      "hash_type": "sha256-sharded-1000000000",
+      "hash_type": "sha256",
       "allow_symlinks": true,
       "shard_size": 1000000000.0
     },

--- a/tests/_signing/testdata/signing/TestPayload/empty_model_file_small_shards
+++ b/tests/_signing/testdata/signing/TestPayload/empty_model_file_small_shards
@@ -12,7 +12,7 @@
   "predicate": {
     "serialization": {
       "method": "shards",
-      "hash_type": "sha256-sharded-8",
+      "hash_type": "sha256",
       "allow_symlinks": true,
       "shard_size": 8.0
     },

--- a/tests/_signing/testdata/signing/TestPayload/empty_model_folder_shard
+++ b/tests/_signing/testdata/signing/TestPayload/empty_model_folder_shard
@@ -12,7 +12,7 @@
   "predicate": {
     "serialization": {
       "method": "shards",
-      "hash_type": "sha256-sharded-1000000000",
+      "hash_type": "sha256",
       "allow_symlinks": true,
       "shard_size": 1000000000.0
     },

--- a/tests/_signing/testdata/signing/TestPayload/empty_model_folder_small_shards
+++ b/tests/_signing/testdata/signing/TestPayload/empty_model_folder_small_shards
@@ -12,7 +12,7 @@
   "predicate": {
     "serialization": {
       "method": "shards",
-      "hash_type": "sha256-sharded-8",
+      "hash_type": "sha256",
       "allow_symlinks": true,
       "shard_size": 8.0
     },

--- a/tests/_signing/testdata/signing/TestPayload/model_folder_with_empty_file_shard
+++ b/tests/_signing/testdata/signing/TestPayload/model_folder_with_empty_file_shard
@@ -12,7 +12,7 @@
   "predicate": {
     "serialization": {
       "method": "shards",
-      "hash_type": "sha256-sharded-1000000000",
+      "hash_type": "sha256",
       "allow_symlinks": true,
       "shard_size": 1000000000.0
     },

--- a/tests/_signing/testdata/signing/TestPayload/model_folder_with_empty_file_small_shards
+++ b/tests/_signing/testdata/signing/TestPayload/model_folder_with_empty_file_small_shards
@@ -12,7 +12,7 @@
   "predicate": {
     "serialization": {
       "method": "shards",
-      "hash_type": "sha256-sharded-8",
+      "hash_type": "sha256",
       "allow_symlinks": true,
       "shard_size": 8.0
     },

--- a/tests/_signing/testdata/signing/TestPayload/sample_model_file_shard
+++ b/tests/_signing/testdata/signing/TestPayload/sample_model_file_shard
@@ -12,7 +12,7 @@
   "predicate": {
     "serialization": {
       "method": "shards",
-      "hash_type": "sha256-sharded-1000000000",
+      "hash_type": "sha256",
       "allow_symlinks": true,
       "shard_size": 1000000000.0
     },

--- a/tests/_signing/testdata/signing/TestPayload/sample_model_file_small_shards
+++ b/tests/_signing/testdata/signing/TestPayload/sample_model_file_small_shards
@@ -12,7 +12,7 @@
   "predicate": {
     "serialization": {
       "method": "shards",
-      "hash_type": "sha256-sharded-8",
+      "hash_type": "sha256",
       "allow_symlinks": true,
       "shard_size": 8.0
     },

--- a/tests/_signing/testdata/signing/TestPayload/sample_model_folder_shard
+++ b/tests/_signing/testdata/signing/TestPayload/sample_model_folder_shard
@@ -12,7 +12,7 @@
   "predicate": {
     "serialization": {
       "method": "shards",
-      "hash_type": "sha256-sharded-1000000000",
+      "hash_type": "sha256",
       "allow_symlinks": true,
       "shard_size": 1000000000.0
     },

--- a/tests/_signing/testdata/signing/TestPayload/sample_model_folder_small_shards
+++ b/tests/_signing/testdata/signing/TestPayload/sample_model_folder_small_shards
@@ -12,7 +12,7 @@
   "predicate": {
     "serialization": {
       "method": "shards",
-      "hash_type": "sha256-sharded-8",
+      "hash_type": "sha256",
       "allow_symlinks": true,
       "shard_size": 8.0
     },

--- a/tests/_signing/testdata/signing/TestPayload/symlink_model_folder_shard
+++ b/tests/_signing/testdata/signing/TestPayload/symlink_model_folder_shard
@@ -12,7 +12,7 @@
   "predicate": {
     "serialization": {
       "method": "shards",
-      "hash_type": "sha256-sharded-1000000000",
+      "hash_type": "sha256",
       "allow_symlinks": true,
       "shard_size": 1000000000.0
     },

--- a/tests/_signing/testdata/signing/TestPayload/symlink_model_folder_small_shards
+++ b/tests/_signing/testdata/signing/TestPayload/symlink_model_folder_small_shards
@@ -12,7 +12,7 @@
   "predicate": {
     "serialization": {
       "method": "shards",
-      "hash_type": "sha256-sharded-8",
+      "hash_type": "sha256",
       "allow_symlinks": true,
       "shard_size": 8.0
     },


### PR DESCRIPTION
#### Summary
Trying to guess serialization format when it uses shard results in

```
ValueError                                Traceback (most recent call last)
<ipython-input-43-18521b474320> in <cell line: 0>()
      1 for model in all_models:
----> 2     verification_config.verify(model, f"{model}_sharded.sig")

5 frames
/usr/local/lib/python3.11/dist-packages/model_signing/hashing.py in _build_stream_hasher(self, hashing_algorithm)
    137             return memory.BLAKE2()
    138
--> 139         raise ValueError(f"Unsupported hashing method {hashing_algorithm}")
    140
    141     def _build_file_hasher_factory(

ValueError: Unsupported hashing method sha256-sharded-1000000000
```

We should use the internal hash name, not the mangled one (so it would be `sha256`).

We'll need another patch release after this for the colab, but this should be the last issue.


#### Release Note
NONE

#### Documentation
NONE