### PR TITLE
add missing mock to prevent unit test network call

### DIFF
--- a/tests/_signing/sigstore_test.py
+++ b/tests/_signing/sigstore_test.py
@@ -276,7 +276,9 @@ class TestSigning:
         expected_manifest = self._verify_dsse_signature(signature_path)
         assert expected_manifest == manifest
 
-    def test_sign_identity_token_precedence(self, mocked_oidc_provider):
+    def test_sign_identity_token_precedence(
+        self, mocked_oidc_provider, mocked_sigstore_signer
+    ):
         signer = sigstore.Signer(identity_token="provided_token")
         token = signer._get_identity_token()
         assert token == "provided_token"


### PR DESCRIPTION
#### Summary
We forgot to pass one of the relevant mocks, which was causing this test to reach out to "tuf-repo-cdn.sigstore.dev". Occasionally this call would fail and the CI run with an error:

  "sigstore.errors.TUFError: Failed to refresh TUF metadata"

Verified by running the tests in a namespace without network:

  `unshare --map-root-user --net pytest -m "not integration"`


Fixes #401

#### Release Note
NONE

#### Documentation
NONE
