### PR TITLE
Also display the fingerprint of the signing certificate

### DIFF
--- a/src/model_signing/_signing/sign_certificate.py
+++ b/src/model_signing/_signing/sign_certificate.py
@@ -175,15 +175,15 @@ class Verifier(sigstore_pb.Verifier):
         max_signing_time = signing_certificate.not_valid_before_utc
         self._store.set_time(max_signing_time)
 
-        signing_certificate_ssl = _to_openssl_certificate(
-            signing_chain.certificates[0].raw_bytes, False
-        )
         trust_chain_ssl = [
             _to_openssl_certificate(
                 certificate.raw_bytes, self._log_fingerprints
             )
             for certificate in signing_chain.certificates[1:]
         ]
+        signing_certificate_ssl = _to_openssl_certificate(
+            signing_chain.certificates[0].raw_bytes, self._log_fingerprints
+        )
 
         store_context = crypto.X509StoreContext(
             self._store, signing_certificate_ssl, trust_chain_ssl


### PR DESCRIPTION
#### Summary

Also display the fingerprint of the signing certficate. Adjust the ordering so that it is always shown last as the one corresponding to the signature-verifying key.

