### PR TITLE
Add compatibility layer with v0.2 signatures

### DIFF
--- a/src/model_signing/_signing/sign_certificate.py
+++ b/src/model_signing/_signing/sign_certificate.py
@@ -153,7 +153,7 @@ class Verifier(sigstore_pb.Verifier):
             # Here, we patch over a bug in `pae` which mixed unicode `str` and
             # `bytes`. As a result, additional escape characters were added to
             # the material that got signed over.
-            self._public_key.verify(
+            public_key.verify(
                 envelope.signatures[0].sig,
                 sigstore_pb.pae_compat(envelope.payload),
                 ec.ECDSA(ec_key.get_ec_key_hash(public_key)),

--- a/src/model_signing/_signing/sign_certificate.py
+++ b/src/model_signing/_signing/sign_certificate.py
@@ -156,7 +156,13 @@ class Verifier(sigstore_pb.Verifier):
             public_key.verify(
                 envelope.signatures[0].sig,
                 sigstore_pb.pae_compat(envelope.payload),
-                ec.ECDSA(ec_key.get_ec_key_hash(public_key)),
+                # Note another bug here: the v0.2 signatures were generated with
+                # hardcoded SHA256 hash, instead of the one that matches the
+                # key type. To verify those signatures, we have to hardcode this
+                # here too (instead of `ec_key.get_ec_key_hash(public_key)`).
+                # For the hardcode path see:
+                # https://github.com/sigstore/model-transparency/blob/9737f0e28349bf43897857ada7beaa22ec18e9a6/src/model_signing/signature/key.py#L103
+                ec.ECDSA(hashes.SHA256()),
             )
 
         return envelope.payload_type, envelope.payload

--- a/src/model_signing/_signing/sign_sigstore_pb.py
+++ b/src/model_signing/_signing/sign_sigstore_pb.py
@@ -65,6 +65,32 @@ def pae(raw_payload: bytes) -> bytes:
     return b" ".join([pae_str.encode("utf-8"), raw_payload])
 
 
+def pae_compat(raw_payload: bytes) -> bytes:
+    """Generates the PAE encoding of statement from the payload.
+
+    This is the same as `pae`, but using the version as defined in v0.2.0 of the
+    `model_signing` library. Due to a bug in that implementation, signatures
+    generated at that version have to be verified using this compat patch. The
+    issue is that the raw payload, which is bytes, is added to a string and then
+    encoded back as bytes, so we get additional escape characters included.
+
+    Args:
+        payload: The raw payload to encode.
+
+    Returns:
+        The encoded statement from the payload.
+    """
+    payload_type = signing._IN_TOTO_JSON_PAYLOAD_TYPE
+    payload_type_length = len(payload_type)
+    payload_length = len(raw_payload)
+    # Notice bug here!
+    pae_str = (
+        f"DSSEV1 {payload_type_length} {payload_type} "
+        f"{payload_length} {raw_payload}"
+    )
+    return pae_str.encode("utf-8")
+
+
 class Signature(signing.Signature):
     """Sigstore signature support, wrapping around `bundle_pb.Bundle`."""
 


### PR DESCRIPTION
#### Summary
This is temporary but we need to ensure that signatures that were generated using the v0.2 CLI can still be verified at v1.0 and later.

There are 3 issues that we needed to fix:

- the PAE encoding mixed `bytes` and `str` types resulting in additional escaping being added to the statement that gets signed. Verification must replicate the same mix-up to gurantee that the signed material can be verified.
- the public key extracted from the certificate during verification was hard coded to use a hash of SHA256 instead of the one that should match the key type. Since this was using `cryptography.hazmat` there was no verification. All signatures generated at v0.2 using certificates are not really valid, but we'll support verifying them as they are.
- the in-toto predicate was different: v0.2 is not compatible with any model signature extensions, is not extensible and could be manipulated to be incomplete (not catching all possible alterations of a model). Fortunately, we used different predicate types, so it is easy to catch and add the support.

Note that this support is only added for verification size. Any new signature must be generated using the v1.0 format.

#### Release Note
Need to add to changelog

#### Documentation
Need to document the current model format better.