### PR TITLE
[NFC] Differentiate certificates: config vs verify

### DIFF
--- a/src/model_signing/_signing/sign_certificate.py
+++ b/src/model_signing/_signing/sign_certificate.py
@@ -98,10 +98,20 @@ class Signer(ec_key.Signer):
         )
 
 
-def _log_cert_fingerprint(cert, hash_alg: hashes.Hash) -> None:
-    fp = cert.fingerprint(hash_alg)
+def _log_certificate_fingerprint(
+    where: str, certificate: x509.Certificate, hash_algorithm: hashes.Hash
+) -> None:
+    """Log the fingerprint of a certificate, for debugging.
+
+    Args:
+        where: Location of where this gets called from, useful for debugging.
+        certificate: Certificate to compute fingerprint of and log.
+        hash_algorithm: The algorithm used to compute the fingerprint.
+    """
+    fp = certificate.fingerprint(hash_algorithm)
     logger.info(
-        f"{hash_alg.name} Fingerprint: {':'.join(f'{b:02X}' for b in fp)}"
+        f"[{where:^8}] {hash_algorithm.name} "
+        f"Fingerprint: {':'.join(f'{b:02X}' for b in fp)}"
     )
 
 
@@ -134,7 +144,9 @@ class Verifier(sigstore_pb.Verifier):
         self._store = crypto.X509Store()
         for certificate in certificates:
             if self._log_fingerprints:
-                _log_cert_fingerprint(certificate, hashes.SHA256())
+                _log_certificate_fingerprint(
+                    "init", certificate, hashes.SHA256()
+                )
             self._store.add_cert(crypto.X509.from_cryptography(certificate))
 
     @override
@@ -164,7 +176,7 @@ class Verifier(sigstore_pb.Verifier):
         def _to_openssl_certificate(certificate_bytes, log_fingerprints):
             cert = x509.load_der_x509_certificate(certificate_bytes)
             if log_fingerprints:
-                _log_cert_fingerprint(cert, hashes.SHA256())
+                _log_certificate_fingerprint("verify", cert, hashes.SHA256())
             return crypto.X509.from_cryptography(cert)
 
         signing_chain = verification_material.x509_certificate_chain


### PR DESCRIPTION
#### Summary

When passing the `--log_fingerprints` flag we log fingerprints for all certificates found, both during initializing the verification configuration and during verification itself. There needs to be a way to differentiate between these two, to help with debugging.

I also added missing docstring, type annotation and made variable names be more informative.

There are no functional changes here, just the format during verification changes from

```
sha256 Fingerprint: 08:DC:02:65:CD:BE:C8:55:D5:3B:36:FA:49:F1:01:95:47:AE:D1:B1:11:87:6B:1F:76:1F:AE:BC:BF:C1:88:9C
sha256 Fingerprint: AA:01:1B:A7:96:2A:BE:36:37:A6:A6:7E:C9:86:19:D8:64:2F:50:E4:D1:47:90:55:F9:3B:B6:A1:A6:43:91:B6
sha256 Fingerprint: 08:DC:02:65:CD:BE:C8:55:D5:3B:36:FA:49:F1:01:95:47:AE:D1:B1:11:87:6B:1F:76:1F:AE:BC:BF:C1:88:9C
sha256 Fingerprint: 03:6F:F1:A9:01:3F:DB:4F:29:E8:E2:AA:14:13:B0:93:D2:F3:5A:68:90:6E:9C:92:DC:85:45:BD:80:34:0B:87
```

to

```
[  init  ] sha256 Fingerprint: 08:DC:02:65:CD:BE:C8:55:D5:3B:36:FA:49:F1:01:95:47:AE:D1:B1:11:87:6B:1F:76:1F:AE:BC:BF:C1:88:9C
[ verify ] sha256 Fingerprint: AA:01:1B:A7:96:2A:BE:36:37:A6:A6:7E:C9:86:19:D8:64:2F:50:E4:D1:47:90:55:F9:3B:B6:A1:A6:43:91:B6
[ verify ] sha256 Fingerprint: 08:DC:02:65:CD:BE:C8:55:D5:3B:36:FA:49:F1:01:95:47:AE:D1:B1:11:87:6B:1F:76:1F:AE:BC:BF:C1:88:9C
[ verify ] sha256 Fingerprint: 03:6F:F1:A9:01:3F:DB:4F:29:E8:E2:AA:14:13:B0:93:D2:F3:5A:68:90:6E:9C:92:DC:85:45:BD:80:34:0B:87
```
