### PR TITLE
[NFC] Add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!-- Thanks for opening a pull request! Please do not just delete this text. -->
+
+#### Summary
+<!--
+ Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
+
+Please remember to:
+- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
+issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
+  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
+- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
+
+Thank you :)
+-->
+
+##### Checklist
+
+- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
+- [ ] All new code has docstrings and type annotations
+- [ ] Public facing changes are paired with documentation changes
+- [ ] Release note has been added to CHANGELOG.md if needed
+
+<!--
+Add a release note for each of the following conditions in CHANGELOG.md:
+
+* Model signature changes (additions, deletions, updates)
+* API additions: new functions, new arguments, new supported signing methods, etc.
+* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
+* New features and improvements, including behavioural changes, UI changes and CLI changes
+* Bug fixes and fixes of previous known issues
+* Deprecation warnings, breaking changes, or compatibility notes
+
+Use past-tense.
+
+-->


### PR DESCRIPTION
#### Summary

This is to ensure that we have a checklist that reminds people to add to `CHANGELOG.md` (added in #444), sign the commits, add docstrings, type annotations and tests. Remind about updating documentation. Give on point examples on when the changelog needs to be updated.

Previous template (global across all repos) used two sections that were usually replaced with `NONE` or deleted. These are no longer here.
