### PR TITLE
Add forgotten checkbox about testing code

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@ Thank you :)
 
 - [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
 - [ ] All new code has docstrings and type annotations
+- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
 - [ ] Public facing changes are paired with documentation changes
 - [ ] Release note has been added to CHANGELOG.md if needed
 


### PR DESCRIPTION
#### Summary
I forgot to add it, even though I mentioned it in #445 

But at least now we can check that it's working :)

##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code has docstrings and type annotations
- [x] Public facing changes are paired with documentation changes
- [x] Release note has been added to CHANGELOG.md if needed