### PR TITLE
Prepare for v1.0.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ All versions prior to 1.0.0 are untracked.
 
 ## [Unreleased]
 
+## [1.0.1] - 2024-04-18
+
+### Added
+- Added support for pre v1.0 signatures used in production. This is only provided for verification and replicates the experimental behavior at v0.2, bug for bug.
+- Added support for displaying fingerprints of certificates when using signing certificates
+
+### Fixed
+- Fix bug in CLI scripts where even if signature verification failed, the script would also output that verification passed and exit with success error code.
+- Docker containers wrapping around the CLI have been changed to support the updated CLI
 
 ## [1.0.0] - 2024-04-04
 
@@ -24,5 +33,6 @@ All versions prior to 1.0.0 are untracked.
 - [Demo notebook](https://colab.sandbox.google.com/drive/18IB_uipduXYq0ohMxJv2xHfeihLIcGMT) to showcase API and CLI examples.
 
 
-[Unreleased]: https://github.com/sigstore/model-transparency/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/sigstore/model-transparency/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/sigstore/model-transparency/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/sigstore/model-transparency/compare/v0.1.0...v1.0.0

--- a/src/model_signing/__init__.py
+++ b/src/model_signing/__init__.py
@@ -125,7 +125,7 @@ from model_signing import signing
 from model_signing import verifying
 
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 
 __all__ = ["hashing", "signing", "verifying", "manifest"]


### PR DESCRIPTION
#### Summary

Modified the changelog and the version number to prepare for the v1.0.1 release which should fix the bug where even if signature verification failed the CLI proceeded to exit with a successful message (after printing the verification error).

This patch release also adds support for verifying v0.2 signatures used in production, as a temporary stop-breakage solution. This is bug-for-bug compatibility, given that fixing the existing bugs would make those signatures impossible to validate. Plan is to keep this support around until users migrate away.

##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code has docstrings and type annotations
- [x] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to higlight lines not covered by tests.
- [x] Public facing changes are paired with documentation changes
- [x] Release note has been added to CHANGELOG.md if needed