### PR TITLE
Record and apply ignored paths

### DIFF
--- a/src/model_signing/_signing/signing.py
+++ b/src/model_signing/_signing/signing.py
@@ -215,6 +215,13 @@ class Payload:
           "method": "files",
           "hash_type": "sha256",
           "allow_symlinks": true
+          "ignore_paths": [
+            "model.sig",
+            ".git",
+            ".gitattributes",
+            ".github",
+            ".gitignore"
+          ],
         },
         "resources": [
           {

--- a/src/model_signing/hashing.py
+++ b/src/model_signing/hashing.py
@@ -337,7 +337,11 @@ class Config:
         Returns:
             The new hashing configuration with a new set of ignored paths.
         """
-        self._ignored_paths = frozenset({pathlib.Path(p) for p in paths})
+        # Use relpath to possibly fix weird paths like '../a/b' -> 'b'
+        # when '../a/' is a no-op
+        self._ignored_paths = frozenset(
+            {pathlib.Path(os.path.relpath(p)) for p in paths}
+        )
         self._ignore_git_paths = ignore_git_paths
         return self
 

--- a/src/model_signing/hashing.py
+++ b/src/model_signing/hashing.py
@@ -142,7 +142,14 @@ class Config:
 
     def hash(self, model_path: PathLike) -> manifest.Manifest:
         """Hashes a model using the current configuration."""
-        ignored_paths = [path for path in self._ignored_paths]
+        # All paths in ignored_paths must have model_path as prefix
+        ignored_paths = []
+        for p in self._ignored_paths:
+            rp = os.path.relpath(p, model_path)
+            # rp may start with "../" if it is not relative to model_path
+            if not rp.startswith("../"):
+                ignored_paths.append(pathlib.Path(os.path.join(model_path, rp)))
+
         if self._ignore_git_paths:
             ignored_paths.extend(
                 [

--- a/src/model_signing/hashing.py
+++ b/src/model_signing/hashing.py
@@ -145,7 +145,15 @@ class Config:
         ignored_paths = [path for path in self._ignored_paths]
         if self._ignore_git_paths:
             ignored_paths.extend(
-                [".git/", ".gitattributes", ".github/", ".gitignore"]
+                [
+                    os.path.join(model_path, p)
+                    for p in [
+                        ".git/",
+                        ".gitattributes",
+                        ".github/",
+                        ".gitignore",
+                    ]
+                ]
             )
 
         return self._serializer.serialize(

--- a/src/model_signing/hashing.py
+++ b/src/model_signing/hashing.py
@@ -245,6 +245,7 @@ class Config:
         chunk_size: int = 1048576,
         max_workers: Optional[int] = None,
         allow_symlinks: bool = False,
+        ignore_paths: Iterable[pathlib.Path] = frozenset(),
     ) -> Self:
         """Configures serialization to build a manifest of (file, hash) pairs.
 
@@ -271,6 +272,7 @@ class Config:
             self._build_file_hasher_factory(hashing_algorithm, chunk_size),
             max_workers=max_workers,
             allow_symlinks=allow_symlinks,
+            ignore_paths=ignore_paths,
         )
         return self
 
@@ -338,3 +340,17 @@ class Config:
         self._ignored_paths = frozenset({pathlib.Path(p) for p in paths})
         self._ignore_git_paths = ignore_git_paths
         return self
+
+    def add_ignored_paths(
+        self, *, model_path: PathLike, paths: Iterable[PathLike]
+    ) -> None:
+        """Add more paths to ignore to existing set of paths.
+
+        Args:
+            model_path: The path to the model
+            paths: Additional paths to ignore. All path must be relative to
+                   the model directory.
+        """
+        newset = set(self._ignored_paths)
+        newset.update([os.path.join(model_path, p) for p in paths])
+        self._ignored_paths = newset

--- a/src/model_signing/manifest.py
+++ b/src/model_signing/manifest.py
@@ -339,7 +339,11 @@ class _FileSerialization(SerializationType):
     @classmethod
     @override
     def _from_args(cls, args: dict[str, Any]) -> Self:
-        return cls(args["hash_type"], args["allow_symlinks"])
+        return cls(
+            args["hash_type"],
+            args["allow_symlinks"],
+            args.get("ignore_paths", frozenset()),
+        )
 
     @override
     def new_item(self, name: str, digest: hashing.Digest) -> ManifestItem:

--- a/src/model_signing/manifest.py
+++ b/src/model_signing/manifest.py
@@ -305,7 +305,12 @@ class SerializationType(metaclass=abc.ABCMeta):
 class _FileSerialization(SerializationType):
     method: Final[str] = "files"
 
-    def __init__(self, hash_type: str, allow_symlinks: bool = False):
+    def __init__(
+        self,
+        hash_type: str,
+        allow_symlinks: bool = False,
+        ignore_paths: Iterable[pathlib.Path] = frozenset(),
+    ):
         """Records the manifest serialization type for serialization by files.
 
         We only need to record the hashing engine used and whether symlinks are
@@ -317,15 +322,19 @@ class _FileSerialization(SerializationType):
         """
         self._hash_type = hash_type
         self._allow_symlinks = allow_symlinks
+        self._ignore_paths = [str(p) for p in ignore_paths]
 
     @property
     @override
     def serialization_parameters(self) -> dict[str, Any]:
-        return {
+        res = {
             "method": self.method,
             "hash_type": self._hash_type,
             "allow_symlinks": self._allow_symlinks,
         }
+        if self._ignore_paths:
+            res["ignore_paths"] = self._ignore_paths
+        return res
 
     @classmethod
     @override

--- a/src/model_signing/verifying.py
+++ b/src/model_signing/verifying.py
@@ -97,6 +97,11 @@ class Config:
 
         if self._hashing_config is None:
             self._guess_hashing_config(expected_manifest)
+        if "ignore_paths" in expected_manifest.serialization_type:
+            self._hashing_config.add_ignored_paths(
+                model_path=model_path,
+                paths=expected_manifest.serialization_type["ignore_paths"],
+            )
         actual_manifest = self._hashing_config.hash(model_path)
 
         if actual_manifest != expected_manifest:
@@ -127,6 +132,7 @@ class Config:
             self._hashing_config = hashing.Config().use_file_serialization(
                 hashing_algorithm=args["hash_type"],
                 allow_symlinks=args["allow_symlinks"],
+                ignore_paths=args.get("ignore_paths", frozenset()),
             )
         elif method == "shards":
             self._hashing_config = hashing.Config().use_shard_serialization(


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary

The following changes record the signer-ignored files in the predicate of the signature and retrieve them from there when verifying. With this change it should not be necessary for a verifier to use the `--ignore-paths` option IF no changes were made to the original files and directories.

Resolves: #429 

Tests will be added once #455 has been merged.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [X] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [X] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
