### PR TITLE
Fix and test the sharded file hasher

### DIFF
--- a/src/model_signing/_serialization/file_shard.py
+++ b/src/model_signing/_serialization/file_shard.py
@@ -17,6 +17,7 @@
 from collections.abc import Callable, Iterable
 import concurrent.futures
 import itertools
+import os
 import pathlib
 from typing import Optional
 
@@ -64,6 +65,7 @@ class Serializer(serialization.Serializer):
         *,
         max_workers: Optional[int] = None,
         allow_symlinks: bool = False,
+        ignore_paths: Iterable[pathlib.Path] = frozenset(),
     ):
         """Initializes an instance to serialize a model with this serializer.
 
@@ -78,10 +80,12 @@ class Serializer(serialization.Serializer):
             allow_symlinks: Controls whether symbolic links are included. If a
               symlink is present but the flag is `False` (default) the
               serialization would raise an error.
+            ignore_paths: The paths of files to ignore.
         """
         self._hasher_factory = sharded_hasher_factory
         self._max_workers = max_workers
         self._allow_symlinks = allow_symlinks
+        self._ignore_paths = ignore_paths
 
         # Precompute some private values only once by using a mock file hasher.
         # None of the arguments used to build the hasher are used.
@@ -93,6 +97,7 @@ class Serializer(serialization.Serializer):
             hasher._content_hasher.digest_name,
             self._shard_size,
             self._allow_symlinks,
+            self._ignore_paths,
         )
 
     @override
@@ -142,8 +147,29 @@ class Serializer(serialization.Serializer):
             for future in concurrent.futures.as_completed(futures):
                 manifest_items.append(future.result())
 
+        # Recreate serialization_description for new ignore_paths
+        if ignore_paths:
+            rel_ignore_paths = []
+            for p in ignore_paths:
+                rp = os.path.relpath(p, model_path)
+                # rp may start with "../" if it is not relative to model_path
+                if not rp.startswith("../"):
+                    rel_ignore_paths.append(pathlib.Path(rp))
+
+            hasher = self._hasher_factory(pathlib.Path(), 0, 1)
+            self._serialization_description = manifest._ShardSerialization(
+                hasher._content_hasher.digest_name,
+                self._shard_size,
+                self._allow_symlinks,
+                frozenset(list(self._ignore_paths) + rel_ignore_paths),
+            )
+
+        model_name = model_path.name
+        if not model_name or model_name == "..":
+            model_name = os.path.basename(model_path.resolve())
+
         return manifest.Manifest(
-            model_path.name, manifest_items, self._serialization_description
+            model_name, manifest_items, self._serialization_description
         )
 
     def _get_shards(

--- a/src/model_signing/hashing.py
+++ b/src/model_signing/hashing.py
@@ -291,6 +291,7 @@ class Config:
         shard_size: int = 1_000_000_000,
         max_workers: Optional[int] = None,
         allow_symlinks: bool = False,
+        ignore_paths: Iterable[pathlib.Path] = frozenset(),
     ) -> Self:
         """Configures serialization to build a manifest of (shard, hash) pairs.
 
@@ -311,6 +312,7 @@ class Config:
             allow_symlinks: Controls whether symbolic links are included. If a
               symlink is present but the flag is `False` (default) the
               serialization would raise an error.
+            ignore_paths: Paths of files to ignore.
 
         Returns:
             The new hashing configuration with the new serialization method.
@@ -321,6 +323,7 @@ class Config:
             ),
             max_workers=max_workers,
             allow_symlinks=allow_symlinks,
+            ignore_paths=ignore_paths,
         )
         return self
 

--- a/src/model_signing/manifest.py
+++ b/src/model_signing/manifest.py
@@ -355,7 +355,11 @@ class _ShardSerialization(SerializationType):
     method: Final[str] = "shards"
 
     def __init__(
-        self, hash_type: str, shard_size: int, allow_symlinks: bool = False
+        self,
+        hash_type: str,
+        shard_size: int,
+        allow_symlinks: bool = False,
+        ignore_paths: Iterable[pathlib.Path] = frozenset(),
     ):
         """Records the manifest serialization type for serialization by files.
 
@@ -367,26 +371,34 @@ class _ShardSerialization(SerializationType):
         Args:
             hash_type: A string representation of the hash algorithm.
             allow_symlinks: Controls whether symbolic links are included.
+            ignore_paths: Paths of files to ignore.
         """
         self._hash_type = hash_type
         self._allow_symlinks = allow_symlinks
         self._shard_size = shard_size
+        self._ignore_paths = [str(p) for p in ignore_paths]
 
     @property
     @override
     def serialization_parameters(self) -> dict[str, Any]:
-        return {
+        res = {
             "method": self.method,
             "hash_type": self._hash_type,
             "shard_size": self._shard_size,
             "allow_symlinks": self._allow_symlinks,
         }
+        if self._ignore_paths:
+            res["ignore_paths"] = self._ignore_paths
+        return res
 
     @classmethod
     @override
     def _from_args(cls, args: dict[str, Any]) -> Self:
         return cls(
-            args["hash_type"], args["shard_size"], args["allow_symlinks"]
+            args["hash_type"],
+            args["shard_size"],
+            args["allow_symlinks"],
+            args.get("ignore_paths", frozenset()),
         )
 
     @override

--- a/src/model_signing/verifying.py
+++ b/src/model_signing/verifying.py
@@ -139,6 +139,7 @@ class Config:
                 hashing_algorithm=args["hash_type"],
                 shard_size=args["shard_size"],
                 allow_symlinks=args["allow_symlinks"],
+                ignore_paths=args.get("ignore_paths", frozenset()),
             )
         else:
             raise ValueError("Cannot guess the hashing configuration")


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary

This PR brings the state of the sharded file hasher to that of the simple file hasher and adds a test case for the shareded file hasher derived from the certificate sign+verify test.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [X] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [X] All new code has docstrings and type annotations
- [X] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
