### PR TITLE
lazy initialize the default SigstoreSigner at signing time

### DIFF
--- a/src/model_signing/signing.py
+++ b/src/model_signing/signing.py
@@ -87,7 +87,8 @@ class Config:
     def __init__(self):
         """Initializes the default configuration for signing."""
         self._hashing_config = hashing.Config()
-        self.use_sigstore_signer()
+        # lazy initialize default signer at signing to avoid network calls
+        self._signer = None
 
     def sign(
         self, model_path: hashing.PathLike, signature_path: hashing.PathLike
@@ -98,6 +99,8 @@ class Config:
             model_path: The path to the model to sign.
             signature_path: The path of the resulting signature.
         """
+        if not self._signer:
+            self._signer = self.use_sigstore_signer()
         manifest = self._hashing_config.hash(model_path)
         payload = signing.Payload(manifest)
         signature = self._signer.sign(payload)


### PR DESCRIPTION


<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
This avoids connecting to Sigstore and TUF infrastructure when configuring a different signing configuration, e.g.:

    signing.Config().use_certificate_signer(...)

Users who want to eagerly initialize the SigstoreSigner can still do so:

    signing.Config().use_sigstore_signer(...)

See https://github.com/sigstore/model-transparency/pull/465#issuecomment-2898637694
##### Checklist

- [X] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [X] All new code has docstrings and type annotations
- [X] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
