### PR TITLE
Fix handling paths to certs from `certifi.where()`

### DIFF
--- a/src/model_signing/_signing/sign_certificate.py
+++ b/src/model_signing/_signing/sign_certificate.py
@@ -136,7 +136,13 @@ class Verifier(sigstore_pb.Verifier):
         self._log_fingerprints = log_fingerprints
 
         if not certificate_chain_paths:
-            certificate_chain_paths = [pathlib.Path(p) for p in certifi.where()]
+            os_certs = certifi.where()
+            if isinstance(os_certs, list):
+                certificate_chain_paths = [pathlib.Path(p) for p in os_certs]
+            elif isinstance(os_certs, str):
+                certificate_chain_paths = [pathlib.Path(os_certs)]
+            else:
+                raise ValueError("Could not determine signing certificates")
 
         certificates = x509.load_pem_x509_certificates(
             b"".join([path.read_bytes() for path in certificate_chain_paths])

--- a/src/model_signing/_signing/sign_certificate.py
+++ b/src/model_signing/_signing/sign_certificate.py
@@ -136,13 +136,7 @@ class Verifier(sigstore_pb.Verifier):
         self._log_fingerprints = log_fingerprints
 
         if not certificate_chain_paths:
-            os_certs = certifi.where()
-            if isinstance(os_certs, list):
-                certificate_chain_paths = [pathlib.Path(p) for p in os_certs]
-            elif isinstance(os_certs, str):
-                certificate_chain_paths = [pathlib.Path(os_certs)]
-            else:
-                raise ValueError("Could not determine signing certificates")
+            certificate_chain_paths = [pathlib.Path(certifi.where())]
 
         certificates = x509.load_pem_x509_certificates(
             b"".join([path.read_bytes() for path in certificate_chain_paths])


### PR DESCRIPTION
#### Summary

If `certifi.where()` returns a single string, we were creating multiple `pathlib.Path` objects for each character in the string, instead of wrapping the entire path string in `pathlib.Path`.

This is a type error bug, due to the fact that strings in Python are sometimes lists and sometimes not.

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

