### PR TITLE
feat(oauth): add --oauth_force_oob flag to support manual OAuth flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All versions prior to 1.0.0 are untracked.
 
 ## [Unreleased]
 
+- cli: `model_signing sign` now supports the `--oauth-force-oob` option (default: False)
+
 ## [1.0.1] - 2024-04-18
 
 ### Added

--- a/src/model_signing/_cli.py
+++ b/src/model_signing/_cli.py
@@ -214,6 +214,15 @@ def _sign() -> None:
         "from OIDC flow or from the environment."
     ),
 )
+@click.option(
+    "--oauth_force_oob",
+    is_flag=True,
+    default=False,
+    help=(
+        "Force an out-of-band OAuth flow and do not automatically start "
+        "the default web browser."
+    ),
+)
 def _sign_sigstore(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
@@ -221,6 +230,7 @@ def _sign_sigstore(
     signature: pathlib.Path,
     use_ambient_credentials: bool,
     use_staging: bool,
+    oauth_force_oob: bool,
     identity_token: Optional[str] = None,
 ) -> None:
     """Sign using Sigstore (DEFAULT signing method).
@@ -244,6 +254,7 @@ def _sign_sigstore(
             use_ambient_credentials=use_ambient_credentials,
             use_staging=use_staging,
             identity_token=identity_token,
+            force_oob=oauth_force_oob,
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
                 paths=list(ignore_paths) + [signature],

--- a/src/model_signing/_signing/sign_sigstore.py
+++ b/src/model_signing/_signing/sign_sigstore.py
@@ -67,6 +67,7 @@ class Signer(signing.Signer):
         use_ambient_credentials: bool = True,
         use_staging: bool = False,
         identity_token: Optional[str] = None,
+        force_oob: bool = False,
     ):
         """Initializes Sigstore signers.
 
@@ -83,6 +84,11 @@ class Signer(signing.Signer):
               identity via OIDC will start.
             use_staging: Use staging configurations, instead of production. This
               is supposed to be set to True only when testing. Default is False.
+            force_oob: If True, forces an out-of-band (OOB) OAuth flow. If set,
+              the OAuth authentication will not attempt to open the default web
+              browser. Instead, it will display a URL and code for manual
+              authentication. Default is False, which means the browser will be
+              opened automatically if possible.
             identity_token: An explicit identity token to use when signing,
               taking precedence over any ambient credential or OAuth workflow.
         """
@@ -98,6 +104,7 @@ class Signer(signing.Signer):
 
         self._use_ambient_credentials = use_ambient_credentials
         self._identity_token = identity_token
+        self._force_oob = force_oob
 
     def _get_identity_token(self) -> sigstore_oidc.IdentityToken:
         """Obtains an identity token to use in signing.
@@ -114,7 +121,7 @@ class Signer(signing.Signer):
             if token:
                 return sigstore_oidc.IdentityToken(token)
 
-        return self._issuer.identity_token(force_oob=True)
+        return self._issuer.identity_token(force_oob=self._force_oob)
 
     @override
     def sign(self, payload: signing.Payload) -> Signature:

--- a/src/model_signing/signing.py
+++ b/src/model_signing/signing.py
@@ -121,6 +121,7 @@ class Config:
         oidc_issuer: Optional[str] = None,
         use_ambient_credentials: bool = False,
         use_staging: bool = False,
+        force_oob: bool = False,
         identity_token: Optional[str] = None,
     ) -> Self:
         """Configures the signing to be performed with Sigstore.
@@ -138,6 +139,11 @@ class Config:
               signer identity via OIDC will start.
             use_staging: Use staging configurations, instead of production. This
               is supposed to be set to True only when testing. Default is False.
+            force_oob: If True, forces an out-of-band (OOB) OAuth flow. If set,
+              the OAuth authentication will not attempt to open the default web
+              browser. Instead, it will display a URL and code for manual
+              authentication. Default is False, which means the browser will be
+              opened automatically if possible.
             identity_token: An explicit identity token to use when signing,
               taking precedence over any ambient credential or OAuth workflow.
 
@@ -149,6 +155,7 @@ class Config:
             use_ambient_credentials=use_ambient_credentials,
             use_staging=use_staging,
             identity_token=identity_token,
+            force_oob=force_oob,
         )
         return self
 


### PR DESCRIPTION
**Summary**
This PR introduces the --oauth-force-oob flag to allow users to opt into the out-of-band (OOB) OAuth flow, instead of forcing it by default. The current behavior assumes OOB by default, which causes issues with modern OAuth providers (such as Google) that no longer support urn:ietf:wg:oauth:2.0:oob redirect URIs.

By default, the CLI will now use the standard browser-based redirect flow, improving compatibility and user experience. Users who still require OOB behavior (e.g., in headless environments) can explicitly pass the --oauth-force-oob flag.

This change makes OAuth authentication more flexible, secure, and modern by default.

```
model_signing sign bert-base-uncased --oauth_force_oob
```

```
model_signing sign bert-base-uncased
```

Resolves #470 

##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [x] Public facing changes are paired with documentation changes
- [x] Release note has been added to CHANGELOG.md if needed
