### PR TITLE
cli: Suppress logging from TUF by only enabling logging when needed

### DIFF
--- a/src/model_signing/_cli.py
+++ b/src/model_signing/_cli.py
@@ -25,9 +25,6 @@ import click
 import model_signing
 
 
-logging.basicConfig(format="%(message)s", level=logging.INFO)
-
-
 # Decorator for the commonly used argument for the model path.
 _model_path_argument = click.argument(
     "model_path", type=pathlib.Path, metavar="MODEL_PATH"
@@ -606,6 +603,9 @@ def _verify_certificate(
 
     Note that we don't offer certificate and key management protocols.
     """
+    if log_fingerprints:
+        logging.basicConfig(format="%(message)s", level=logging.INFO)
+
     try:
         model_signing.verifying.Config().use_certificate_verifier(
             certificate_chain=certificate_chain,


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary

The side-effect of previoulsy enabling logging is that the following type of log messages from python-tuf are appearing:

```
Key 6f260089d5923daf20166ca657c543af618346ab971884a99962b01988bbe0c3 failed to verify root
Key 22f4caec6d8e6f9555af66b3d4c3cb06a3bb23fdc7e39c916c61f462e6f52b06 failed to verify root
```
These error messsages from TUF seem to be of no significance for model signing or signature verification. Therefore, enable logging only when needed to largely avoid these messages. Logging is currently only needed when --log_fingerprints is passed.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [X] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
