### PR TITLE
feat: add CLI options for client_id and client_secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All versions prior to 1.0.0 are untracked.
 
 ## [Unreleased]
 
-- cli: `model_signing sign` now supports the `--oauth-force-oob` option (default: False)
+- cli: `model_signing sign` now supports the `--oauth_force_oob` option (default: False)
+- Added support for specifying `--client_id` and `--client_secret` for OIDC authentication.
 
 ## [1.0.1] - 2024-04-18
 

--- a/src/model_signing/_cli.py
+++ b/src/model_signing/_cli.py
@@ -220,6 +220,18 @@ def _sign() -> None:
         "the default web browser."
     ),
 )
+@click.option(
+    "--client_id",
+    type=str,
+    metavar="ID",
+    help="The custom OpenID Connect client ID to use during OAuth2",
+)
+@click.option(
+    "--client_secret",
+    type=str,
+    metavar="SECRET",
+    help="The custom OpenID Connect client secret to use during OAuth2",
+)
 def _sign_sigstore(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
@@ -229,6 +241,8 @@ def _sign_sigstore(
     use_staging: bool,
     oauth_force_oob: bool,
     identity_token: Optional[str] = None,
+    client_id: Optional[str] = None,
+    client_secret: Optional[str] = None,
 ) -> None:
     """Sign using Sigstore (DEFAULT signing method).
 
@@ -252,6 +266,8 @@ def _sign_sigstore(
             use_staging=use_staging,
             identity_token=identity_token,
             force_oob=oauth_force_oob,
+            client_id=client_id,
+            client_secret=client_secret,
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
                 paths=list(ignore_paths) + [signature],

--- a/src/model_signing/_signing/sign_sigstore.py
+++ b/src/model_signing/_signing/sign_sigstore.py
@@ -34,6 +34,9 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import Self
 
+_DEFAULT_CLIENT_ID = "sigstore"
+_DEFAULT_CLIENT_SECRET = ""
+
 
 class Signature(signing.Signature):
     """Sigstore signature support, wrapping around `sigstore_models.Bundle`."""
@@ -68,6 +71,8 @@ class Signer(signing.Signer):
         use_staging: bool = False,
         identity_token: Optional[str] = None,
         force_oob: bool = False,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
     ):
         """Initializes Sigstore signers.
 
@@ -91,6 +96,17 @@ class Signer(signing.Signer):
               opened automatically if possible.
             identity_token: An explicit identity token to use when signing,
               taking precedence over any ambient credential or OAuth workflow.
+             client_id: An optional client ID to use when performing OIDC-based
+              authentication. This is typically used to identify the
+              application making the request to the OIDC provider. If not
+              provided, the default client ID configured by Sigstore will be
+              used.
+            client_secret: An optional client secret to use along with the
+              client ID when authenticating with the OIDC provider. This is
+              required for confidential clients that need to prove their
+              identity to the OIDC provider. If not provided, it is assumed
+              that the client is public or the provider does not require a
+              secret.
         """
         if use_staging:
             self._signing_context = sigstore_signer.SigningContext.staging()
@@ -105,6 +121,8 @@ class Signer(signing.Signer):
         self._use_ambient_credentials = use_ambient_credentials
         self._identity_token = identity_token
         self._force_oob = force_oob
+        self._client_id = client_id or _DEFAULT_CLIENT_ID
+        self._client_secret = client_secret or _DEFAULT_CLIENT_SECRET
 
     def _get_identity_token(self) -> sigstore_oidc.IdentityToken:
         """Obtains an identity token to use in signing.
@@ -121,7 +139,11 @@ class Signer(signing.Signer):
             if token:
                 return sigstore_oidc.IdentityToken(token)
 
-        return self._issuer.identity_token(force_oob=self._force_oob)
+        return self._issuer.identity_token(
+            force_oob=self._force_oob,
+            client_id=self._client_id,
+            client_secret=self._client_secret,
+        )
 
     @override
     def sign(self, payload: signing.Payload) -> Signature:

--- a/src/model_signing/signing.py
+++ b/src/model_signing/signing.py
@@ -126,6 +126,8 @@ class Config:
         use_staging: bool = False,
         force_oob: bool = False,
         identity_token: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
     ) -> Self:
         """Configures the signing to be performed with Sigstore.
 
@@ -149,6 +151,17 @@ class Config:
               opened automatically if possible.
             identity_token: An explicit identity token to use when signing,
               taking precedence over any ambient credential or OAuth workflow.
+            client_id: An optional client ID to use when performing OIDC-based
+              authentication. This is typically used to identify the
+              application making the request to the OIDC provider. If not
+              provided, the default client ID configured by Sigstore will be
+              used.
+            client_secret: An optional client secret to use along with the
+              client ID when authenticating with the OIDC provider. This is
+              required for confidential clients that need to prove their
+              identity to the OIDC provider. If not provided, it is assumed
+              that the client is public or the provider does not require a
+              secret.
 
         Return:
             The new signing configuration.
@@ -159,6 +172,8 @@ class Config:
             use_staging=use_staging,
             identity_token=identity_token,
             force_oob=force_oob,
+            client_id=client_id,
+            client_secret=client_secret,
         )
         return self
 


### PR DESCRIPTION
**Summary**
This PR adds support for supplying a custom client_id and client_secret when performing OIDC authentication with Sigstore.

This allows users to authenticate using their own registered OAuth clients—such as when using a private Keycloak instance or any enterprise identity provider—rather than relying solely on the default configuration.

**Details**
Adds new optional CLI parameters: --client_id and --client_secret

These values are passed through the signing flow and used in token requests if provided

Backward-compatible: defaults are used if no values are supplied

(Also fixed a small changelog issue from a previous commit)

resolves #474 

##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [x] Public facing changes are paired with documentation changes
- [x] Release note has been added to CHANGELOG.md if needed
