### PR TITLE
add max_workers experiment

### DIFF
--- a/benchmarks/exp_worker.py
+++ b/benchmarks/exp_worker.py
@@ -1,0 +1,64 @@
+# Copyright 2025 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Script for running a benchmark to pick max_workers parameter."""
+
+import argparse
+import timeit
+
+import serialize
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Builds the command line parser for the worker experiment."""
+    parser = argparse.ArgumentParser(
+        description="max_workers benchmark data for model signing"
+    )
+
+    parser.add_argument("path", help="path to model")
+
+    parser.add_argument(
+        "--repeat",
+        help="how many times to repeat each worker count",
+        type=int,
+        default=5,
+    )
+
+    parser.add_argument(
+        "--workers", help="number of workers to benchmark", nargs="+", type=int
+    )
+
+    return parser
+
+
+def _default_workers() -> list[int]:
+    return [1, 2, 4, 8, 12, 16, 24, 32, 48, 64, 80, 96, 128]
+
+
+if __name__ == "__main__":
+    worker_args = build_parser().parse_args()
+
+    workers = worker_args.workers or _default_workers()
+    padding = len(f"{max(workers)}: ")
+    for worker in workers:
+        args = serialize.build_parser().parse_args(
+            [worker_args.path, f"--max_workers={worker}"]
+        )
+        times = timeit.repeat(
+            lambda args=args: serialize.run(args),
+            number=1,
+            repeat=worker_args.repeat,
+        )
+        print(f"{f'{worker}: ':<{padding}}{min(times):10.4f}")


### PR DESCRIPTION
#### Summary
This benchmarking experiment evaluates the effect of the max_workers count on sharded hashing. The worker counts were picked to fall around vCPU counts for common VMs.

Local experiments with a large model (to ignore the effects of OS disk caching) showed a diminishing effect beyond 8 workers, indicating the disk became the bottleneck. By default, we defer to the value selected by the `concurrent.futures` library (cpu_count + 4, up to a maximum of 32).

We likely don't need to increase our value beyond the max of 32, but we may want to advocate for users to set the value lower if disk usage is a concern.

```
python3 benchmarks/exp_worker.py ~/models/Llama-3.1-70B
1:    1064.7986
2:     516.6226
4:     276.0468
8:     223.2531
12:    232.7897
16:    222.8352
24:    222.3078
32:    222.9888
48:    222.4046
64:    222.3379
80:    222.1991
96:    222.3327
128:   222.3440
```

##### Checklist

- [X] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [X] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
