### PR TITLE
Enable setting allow_symlinks on hashing Config and file serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All versions prior to 1.0.0 are untracked.
 - Added tests for verifying signatures created with v0.3.1
 - cli: `model_signing sign` now supports the `--oauth_force_oob` option (default: False)
 - Added support for specifying `--client_id` and `--client_secret` for OIDC authentication.
+- cli: Added support for `--allow_symlinks` option
 
 ## [1.0.1] - 2024-04-18
 

--- a/scripts/tests/test-sign-verify
+++ b/scripts/tests/test-sign-verify
@@ -164,6 +164,11 @@ echo "Testing 'sign/verify' certificate when in subdir of model directory and us
 
 rm -f "$(basename "${sigfile}")"
 mkdir subdir
+
+# Create a symlink'ed file
+echo "foo" > subdir/symlinked
+ln -s subdir/symlinked symlink
+
 pushd subdir 1>/dev/null || exit 1
 
 if ! python -m model_signing \
@@ -173,6 +178,7 @@ if ! python -m model_signing \
 	--signing_certificate "${DIR}/keys/certificate/signing-key-cert.pem" \
 	--certificate_chain "${DIR}/keys/certificate/int-ca-cert.pem" \
 	--ignore-paths "../$(basename "${ignorefile}")" \
+	--allow_symlinks \
 	.. ; then
 	echo "Error: 'sign key' failed"
 	exit 1
@@ -185,6 +191,7 @@ if ! python -m model_signing \
 	--signature "$(basename "${sigfile}")" \
 	--certificate_chain "${DIR}/keys/certificate/ca-cert.pem" \
 	--ignore-paths "$(basename "${ignorefile}")" \
+	--allow_symlinks \
 	. ; then
 	echo "Error: 'sign key' failed"
 	exit 1
@@ -192,7 +199,7 @@ fi
 
 # Check which files are part of signature
 res=$(get_signed_files "${sigfile}")
-exp='["signme-1","signme-2"]'
+exp='["signme-1","signme-2","subdir/symlinked","symlink"]'
 if [ "${res}" != "${exp}" ]; then
 	echo "Error: Unexpected files were signed"
 	echo "Expected: ${exp}"

--- a/src/model_signing/_cli.py
+++ b/src/model_signing/_cli.py
@@ -115,6 +115,14 @@ _signing_certificate_option = click.option(
     help="Path to the signing certificate, as a PEM-encoded file.",
 )
 
+# Decorator for the commonly used option to allow symlinks
+_allow_symlinks_option = click.option(
+    "--allow_symlinks",
+    type=bool,
+    is_flag=True,
+    help="Whether to allow following symlinks when signing or verifying files.",
+)
+
 
 class _PKICmdGroup(click.Group):
     """A custom group to configure the supported PKI methods."""
@@ -194,6 +202,7 @@ def _sign() -> None:
 @_model_path_argument
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_allow_symlinks_option
 @_write_signature_option
 @_sigstore_staging_option
 @click.option(
@@ -236,6 +245,7 @@ def _sign_sigstore(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    allow_symlinks: bool,
     signature: pathlib.Path,
     use_ambient_credentials: bool,
     use_staging: bool,
@@ -269,10 +279,12 @@ def _sign_sigstore(
             client_id=client_id,
             client_secret=client_secret,
         ).set_hashing_config(
-            model_signing.hashing.Config().set_ignored_paths(
+            model_signing.hashing.Config()
+            .set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
             )
+            .set_allow_symlinks(allow_symlinks)
         ).sign(model_path, signature)
     except Exception as err:
         click.echo(f"Signing failed with error: {err}", err=True)
@@ -285,6 +297,7 @@ def _sign_sigstore(
 @_model_path_argument
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_allow_symlinks_option
 @_write_signature_option
 @_private_key_option
 @click.option(
@@ -297,6 +310,7 @@ def _sign_private_key(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    allow_symlinks: bool,
     signature: pathlib.Path,
     private_key: pathlib.Path,
     password: Optional[str] = None,
@@ -318,10 +332,12 @@ def _sign_private_key(
         model_signing.signing.Config().use_elliptic_key_signer(
             private_key=private_key, password=password
         ).set_hashing_config(
-            model_signing.hashing.Config().set_ignored_paths(
+            model_signing.hashing.Config()
+            .set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
             )
+            .set_allow_symlinks(allow_symlinks)
         ).sign(model_path, signature)
     except Exception as err:
         click.echo(f"Signing failed with error: {err}", err=True)
@@ -334,12 +350,14 @@ def _sign_private_key(
 @_model_path_argument
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_allow_symlinks_option
 @_write_signature_option
 @_pkcs11_uri_option
 def _sign_pkcs11_key(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    allow_symlinks: bool,
     signature: pathlib.Path,
     pkcs11_uri: str,
 ) -> None:
@@ -360,10 +378,12 @@ def _sign_pkcs11_key(
         model_signing.signing.Config().use_pkcs11_signer(
             pkcs11_uri=pkcs11_uri
         ).set_hashing_config(
-            model_signing.hashing.Config().set_ignored_paths(
+            model_signing.hashing.Config()
+            .set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
             )
+            .set_allow_symlinks(allow_symlinks)
         ).sign(model_path, signature)
     except Exception as err:
         click.echo(f"Signing failed with error: {err}", err=True)
@@ -376,6 +396,7 @@ def _sign_pkcs11_key(
 @_model_path_argument
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_allow_symlinks_option
 @_write_signature_option
 @_private_key_option
 @_signing_certificate_option
@@ -384,6 +405,7 @@ def _sign_certificate(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    allow_symlinks: bool,
     signature: pathlib.Path,
     private_key: pathlib.Path,
     signing_certificate: pathlib.Path,
@@ -411,10 +433,12 @@ def _sign_certificate(
             signing_certificate=signing_certificate,
             certificate_chain=certificate_chain,
         ).set_hashing_config(
-            model_signing.hashing.Config().set_ignored_paths(
+            model_signing.hashing.Config()
+            .set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
             )
+            .set_allow_symlinks(allow_symlinks)
         ).sign(model_path, signature)
     except Exception as err:
         click.echo(f"Signing failed with error: {err}", err=True)
@@ -427,6 +451,7 @@ def _sign_certificate(
 @_model_path_argument
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_allow_symlinks_option
 @_write_signature_option
 @_pkcs11_uri_option
 @_signing_certificate_option
@@ -435,6 +460,7 @@ def _sign_pkcs11_certificate(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    allow_symlinks: bool,
     signature: pathlib.Path,
     pkcs11_uri: str,
     signing_certificate: pathlib.Path,
@@ -463,10 +489,12 @@ def _sign_pkcs11_certificate(
             signing_certificate=signing_certificate,
             certificate_chain=certificate_chain,
         ).set_hashing_config(
-            model_signing.hashing.Config().set_ignored_paths(
+            model_signing.hashing.Config()
+            .set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
             )
+            .set_allow_symlinks(allow_symlinks)
         ).sign(model_path, signature)
     except Exception as err:
         click.echo(f"Signing failed with error: {err}", err=True)
@@ -497,6 +525,7 @@ def _verify() -> None:
 @_read_signature_option
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_allow_symlinks_option
 @_sigstore_staging_option
 @click.option(
     "--identity",
@@ -517,6 +546,7 @@ def _verify_sigstore(
     signature: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    allow_symlinks: bool,
     identity: str,
     identity_provider: str,
     use_staging: bool,
@@ -537,10 +567,12 @@ def _verify_sigstore(
             oidc_issuer=identity_provider,
             use_staging=use_staging,
         ).set_hashing_config(
-            model_signing.hashing.Config().set_ignored_paths(
+            model_signing.hashing.Config()
+            .set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
             )
+            .set_allow_symlinks(allow_symlinks)
         ).verify(model_path, signature)
     except Exception as err:
         click.echo(f"Verification failed with error: {err}", err=True)
@@ -554,6 +586,7 @@ def _verify_sigstore(
 @_read_signature_option
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_allow_symlinks_option
 @click.option(
     "--public_key",
     type=pathlib.Path,
@@ -566,6 +599,7 @@ def _verify_private_key(
     signature: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    allow_symlinks: bool,
     public_key: pathlib.Path,
 ) -> None:
     """Verity using a public key (paired with a private one).
@@ -585,10 +619,12 @@ def _verify_private_key(
         model_signing.verifying.Config().use_elliptic_key_verifier(
             public_key=public_key
         ).set_hashing_config(
-            model_signing.hashing.Config().set_ignored_paths(
+            model_signing.hashing.Config()
+            .set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
             )
+            .set_allow_symlinks(allow_symlinks)
         ).verify(model_path, signature)
     except Exception as err:
         click.echo(f"Verification failed with error: {err}", err=True)
@@ -602,6 +638,7 @@ def _verify_private_key(
 @_read_signature_option
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_allow_symlinks_option
 @_certificate_root_of_trust_option
 @click.option(
     "--log_fingerprints",
@@ -616,6 +653,7 @@ def _verify_certificate(
     signature: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    allow_symlinks: bool,
     certificate_chain: Iterable[pathlib.Path],
     log_fingerprints: bool,
 ) -> None:
@@ -640,10 +678,12 @@ def _verify_certificate(
             certificate_chain=certificate_chain,
             log_fingerprints=log_fingerprints,
         ).set_hashing_config(
-            model_signing.hashing.Config().set_ignored_paths(
+            model_signing.hashing.Config()
+            .set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
             )
+            .set_allow_symlinks(allow_symlinks)
         ).verify(model_path, signature)
     except Exception as err:
         click.echo(f"Verification failed with error: {err}", err=True)

--- a/src/model_signing/_serialization/file.py
+++ b/src/model_signing/_serialization/file.py
@@ -66,6 +66,10 @@ class Serializer(serialization.Serializer):
             hasher.digest_name, self._allow_symlinks, self._ignore_paths
         )
 
+    def set_allow_symlinks(self, allow_symlinks: bool) -> None:
+        """Set whether following symlinks is allowed."""
+        self._allow_symlinks = allow_symlinks
+
     @override
     def serialize(
         self,

--- a/src/model_signing/_serialization/file_shard.py
+++ b/src/model_signing/_serialization/file_shard.py
@@ -100,6 +100,10 @@ class Serializer(serialization.Serializer):
             self._ignore_paths,
         )
 
+    def set_allow_symlinks(self, allow_symlinks: bool) -> None:
+        """Set whether following symlinks is allowed."""
+        self._allow_symlinks = allow_symlinks
+
     @override
     def serialize(
         self,

--- a/src/model_signing/hashing.py
+++ b/src/model_signing/hashing.py
@@ -139,6 +139,7 @@ class Config:
         self._ignored_paths = frozenset()
         self._ignore_git_paths = True
         self.use_file_serialization()
+        self._allow_symlinks = False
 
     def hash(self, model_path: PathLike) -> manifest.Manifest:
         """Hashes a model using the current configuration."""
@@ -162,6 +163,8 @@ class Config:
                     ]
                 ]
             )
+
+        self._serializer.set_allow_symlinks(self._allow_symlinks)
 
         return self._serializer.serialize(
             pathlib.Path(model_path), ignore_paths=ignored_paths
@@ -368,3 +371,8 @@ class Config:
         newset = set(self._ignored_paths)
         newset.update([os.path.join(model_path, p) for p in paths])
         self._ignored_paths = newset
+
+    def set_allow_symlinks(self, allow_symlinks: bool) -> Self:
+        """Set whether following symlinks is allowed."""
+        self._allow_symlinks = allow_symlinks
+        return self


### PR DESCRIPTION
Add a set_allow_symlinks method to the hashing Config so that this option can be passed onto the file serializers. This method on the Config class seems necessary since its constructor does not have it. Extend the CLI tool with a --allow-symlinks option on all signing and verifying methods and use this option in a scripted test case to test signing of files by following symlinks.

<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [X] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [X] All new code has docstrings and type annotations
- [X] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [X] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
