### PR TITLE
fix(signing): Handle Signature.keyid as empty string for optional values

### DIFF
--- a/src/model_signing/_signing/sign_ec_key.py
+++ b/src/model_signing/_signing/sign_ec_key.py
@@ -105,7 +105,7 @@ class Signer(sigstore_pb.Signer):
                 sigstore_pb.pae(raw_payload),
                 ec.ECDSA(get_ec_key_hash(self._private_key.public_key())),
             ),
-            keyid=None,
+            keyid="",
         )
 
         envelope = intoto_pb.Envelope(

--- a/src/model_signing/_signing/sign_pkcs11.py
+++ b/src/model_signing/_signing/sign_pkcs11.py
@@ -172,7 +172,7 @@ class Signer(sigstore_pb.Signer):
         # Convert plain r & s signature values to ASN.1
         sig = DSASignature.from_p1363(rs_sig).dump()
 
-        raw_signature = intoto_pb.Signature(sig=sig, keyid=None)
+        raw_signature = intoto_pb.Signature(sig=sig, keyid="")
 
         envelope = intoto_pb.Envelope(
             payload=raw_payload,


### PR DESCRIPTION
#### Summary
I left it as an empty string incase in the future we add the option for a user to specify a keyid. With this change, keyid correctly stops showing in the envelope under signatures and also is the correct type as shown in the specs. (All on the issue I opened)

```    
keyid: str = betterproto.string_field(2)
    """
    *Unauthenticated* hint identifying which public key was used.
     OPTIONAL.
    """
```

Resolves #489 

##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

