### PR TITLE
feat(verification): Add PublicKeyIdentifier hash matching and old-sty…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,11 @@ All versions prior to 1.0.0 are untracked.
 - Fix and test the sharded file hasher
 - Added tests for verifying signatures created with v0.3.1
 - cli: `model_signing sign` now supports the `--oauth_force_oob` option (default: False)
-- Added support for specifying `--client_id` and `--client_secret` for OIDC authentication.
+- Added support for specifying `--client_id` and `--client_secret` for OIDC authentication
 - cli: Added support for `--allow_symlinks` option
+- Fix Bundle deserialization error caused by null keyid in DSSE signatures; keyid now serializes as an empty string
+- Implemented public key identifier hash matching for bundle verification
+- Add warning for older verification material formats (e.g., raw public key bytes) during verification, recommending re-signing
 
 ## [1.0.1] - 2024-04-18
 

--- a/src/model_signing/_signing/sign_pkcs11.py
+++ b/src/model_signing/_signing/sign_pkcs11.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections.abc import Iterable
+import hashlib
 import pathlib
 from typing import Optional
 
@@ -191,26 +192,16 @@ class Signer(sigstore_pb.Signer):
     def _get_verification_material(self) -> bundle_pb.VerificationMaterial:
         """Returns the verification material to include in the bundle."""
         public_key = self._public_key
-        key_size = public_key.curve.key_size
 
-        # TODO: Once Python 3.9 support is deprecated revert to using `match`
-        if key_size == 256:
-            key_details = common_pb.PublicKeyDetails.PKIX_ECDSA_P256_SHA_256
-        elif key_size == 384:
-            key_details = common_pb.PublicKeyDetails.PKIX_ECDSA_P384_SHA_384
-        elif key_size == 521:
-            key_details = common_pb.PublicKeyDetails.PKIX_ECDSA_P521_SHA_512
-        else:
-            raise ValueError(f"Unexpected key size {key_size}")
+        raw_bytes = public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+
+        hash_bytes = hashlib.sha256(raw_bytes).digest().hex()
 
         return bundle_pb.VerificationMaterial(
-            public_key=common_pb.PublicKey(
-                raw_bytes=public_key.public_bytes(
-                    encoding=serialization.Encoding.PEM,
-                    format=serialization.PublicFormat.SubjectPublicKeyInfo,
-                ),
-                key_details=key_details,
-            )
+            public_key=common_pb.PublicKeyIdentifier(hint=hash_bytes)
         )
 
 

--- a/src/model_signing/_signing/sign_sigstore_pb.py
+++ b/src/model_signing/_signing/sign_sigstore_pb.py
@@ -22,6 +22,7 @@ validation does not allow those.
 """
 
 import abc
+import json
 import pathlib
 import sys
 from typing import cast
@@ -110,7 +111,8 @@ class Signature(signing.Signature):
     @override
     def read(cls, path: pathlib.Path) -> Self:
         content = path.read_text()
-        return cls(bundle_pb.Bundle().from_json(content))
+        parsed_dict = json.loads(content)
+        return cls(bundle_pb.Bundle().from_dict(parsed_dict))
 
 
 class Signer(signing.Signer):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -165,7 +165,7 @@ class TestSigstoreSigning:
             use_staging=True,
         ).verify(sample_model_folder, signature_path)
 
-        assert [
+        assert get_signed_files(signature_path) == [
             "d0/f00",
             "d0/f01",
             "d0/f02",
@@ -176,7 +176,7 @@ class TestSigstoreSigning:
             "f1",
             "f2",
             "f3",
-        ] == get_signed_files(signature_path)
+        ]
         check_ignore_paths(signature_path, True, [])
         assert get_model_name(signature_path) == os.path.basename(
             sample_model_folder
@@ -214,9 +214,11 @@ class TestKeySigning:
             )
         ).verify(model_path, signature)
 
-        assert [".gitignore", "signme-1", "signme-2"] == get_signed_files(
-            signature
-        )
+        assert get_signed_files(signature) == [
+            ".gitignore",
+            "signme-1",
+            "signme-2",
+        ]
         check_ignore_paths(signature, ignore_git_paths, ["model.sig"])
         assert get_model_name(signature) == os.path.basename(model_path)
 
@@ -233,7 +235,7 @@ class TestKeySigning:
             )
         ).sign(model_path, signature)
 
-        assert ["signme-1", "signme-2"] == get_signed_files(signature)
+        assert get_signed_files(signature) == ["signme-1", "signme-2"]
         check_ignore_paths(
             signature, ignore_git_paths, ["model.sig", "ignored"]
         )
@@ -280,9 +282,11 @@ class TestCertificateSigning:
             )
         ).verify(model_path, signature)
 
-        assert [".gitignore", "signme-1", "signme-2"] == get_signed_files(
-            signature
-        )
+        assert get_signed_files(signature) == [
+            ".gitignore",
+            "signme-1",
+            "signme-2",
+        ]
         check_ignore_paths(signature, ignore_git_paths, ["model.sig"])
         assert get_model_name(signature) == os.path.basename(model_path)
 
@@ -301,7 +305,7 @@ class TestCertificateSigning:
             )
         ).sign(model_path, signature)
 
-        assert ["signme-1", "signme-2"] == get_signed_files(signature)
+        assert get_signed_files(signature) == ["signme-1", "signme-2"]
         check_ignore_paths(
             signature, ignore_git_paths, ["model.sig", "ignored"]
         )
@@ -349,11 +353,11 @@ class TestCertificateSigning:
         )
         # .verify(model_path, signature)
 
-        assert [
+        assert get_signed_files(signature) == [
             ".gitignore:0:4",
             "signme-1:0:8",
             "signme-2:0:8",
-        ] == get_signed_files(signature)
+        ]
         check_ignore_paths(signature, ignore_git_paths, ["model.sig"])
         assert get_model_name(signature) == os.path.basename(model_path)
 
@@ -374,7 +378,7 @@ class TestCertificateSigning:
             .use_shard_serialization()
         ).sign(model_path, signature)
 
-        assert ["signme-1:0:8", "signme-2:0:8"] == get_signed_files(signature)
+        assert get_signed_files(signature) == ["signme-1:0:8", "signme-2:0:8"]
         check_ignore_paths(
             signature, ignore_git_paths, ["model.sig", "ignored"]
         )


### PR DESCRIPTION
#### Summary
- Fixed some tests for linter
- Added more robust parsing for the bundle which was erroring out (Working off of main/sigstore-python)
- Switched PublicKey to PublicKeyIdentifier
- Added error handling + warning to old style verification material (tested verifying older signatures)
- Verification material now checks with user provided public key in verifier
- Updated changelog

Resolves #491 

##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code has docstrings and type annotations
- [x] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [x] Public facing changes are paired with documentation changes
- [x] Release note has been added to CHANGELOG.md if needed