### PR TITLE
build(deps): Make PyKCS11 an optional dependency

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -37,5 +37,5 @@ jobs:
       run: |
         python -m venv venv
         . venv/bin/activate
-        pip install -e .
+        pip install -e .[pkcs11]
         ./scripts/tests/testrunner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All versions prior to 1.0.0 are untracked.
 - cli: `model_signing sign` now supports the `--oauth_force_oob` option (default: False)
 - Added support for specifying `--client_id` and `--client_secret` for OIDC authentication.
 - cli: Added support for `--allow_symlinks` option
+- Added guidance to `README.md` on how to install `model-signing` with PKCS#11 support.
 
 ## [1.0.1] - 2024-04-18
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We support generating signatures via [Sigstore](https://www.sigstore.dev/), a
 tool for making code signatures transparent without requiring management of
 cryptographic key material. But we also support traditional signing methods, so
 models can be signed with public keys or signing certificates as well as
-PKCS #11 enabled devices.
+PKCS #11 enabled devices *(install with `pip install model-signing[pkcs11]` to enable this functionality)*.
 
 The signing part creates a
 [sigstore bundle](https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_bundle.proto)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
   "click",
   "cryptography",
   "in-toto-attestation",
-  "PyKCS11",
   "sigstore",
   "typing_extensions",
 ]
@@ -45,6 +44,11 @@ keywords = [
   "ML security",
   "AI supply chain security",
   "ML supply chain security",
+]
+
+[project.optional-dependencies]
+pkcs11 = [
+    "PyKCS11",
 ]
 
 [project.scripts]
@@ -69,6 +73,9 @@ installer = "pip"
 parallel = true
 randomize = true
 extra-args = ["-m", "not integration"]
+extra-dependencies = [
+    "PyKCS11",
+]
 
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
@@ -112,6 +119,7 @@ Use `hatch run type:check` to check types.
 extra-dependencies = [
   "pytest",
   "pytype",
+  "PyKCS11",
 ]
 installer = "pip"
 python = "3.12"

--- a/src/model_signing/signing.py
+++ b/src/model_signing/signing.py
@@ -50,7 +50,6 @@ from typing import Optional
 from model_signing import hashing
 from model_signing._signing import sign_certificate as certificate
 from model_signing._signing import sign_ec_key as ec_key
-from model_signing._signing import sign_pkcs11 as pkcs11
 from model_signing._signing import sign_sigstore as sigstore
 from model_signing._signing import signing
 
@@ -238,6 +237,13 @@ class Config:
         Return:
             The new signing configuration.
         """
+        try:
+            from model_signing._signing import sign_pkcs11 as pkcs11
+        except ImportError as e:
+            raise RuntimeError(
+                "PKCS #11 functionality requires the 'pkcs11' extra. "
+                "Install with 'pip install model-signing[pkcs11]'."
+            ) from e
         self._signer = pkcs11.Signer(pkcs11_uri, module_paths)
         return self
 
@@ -264,6 +270,14 @@ class Config:
         Return:
             The new signing configuration.
         """
+        try:
+            from model_signing._signing import sign_pkcs11 as pkcs11
+        except ImportError as e:
+            raise RuntimeError(
+                "PKCS #11 functionality requires the 'pkcs11' extra. "
+                "Install with 'pip install model-signing[pkcs11]'."
+            ) from e
+
         self._signer = pkcs11.CertSigner(
             pkcs11_uri,
             signing_certificate,


### PR DESCRIPTION

#### Summary

PyKCS11 has been moved from the main [project.dependencies] list into a new optional dependency group: [project.optional-dependencies.pkcs11].

The from model_signing._signing import sign_pkcs11 import statement has been moved from the top level of signing.py into the signing.Config().use_pkcs11_signer() method.

Resolves #488 

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed
