### PR TITLE
feat: provide informative signature mismatch messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All versions prior to 1.0.0 are untracked.
 - cli: `model_signing sign` now supports the `--oauth_force_oob` option (default: False)
 - Added support for specifying `--client_id` and `--client_secret` for OIDC authentication.
 - cli: Added support for `--allow_symlinks` option
+- Added more informative signature mismatch errors: The `ValueError` raised during model verification when a signature mismatch occurs now includes detailed information
 
 ## [1.0.1] - 2024-04-18
 


### PR DESCRIPTION
#### Summary
This change introduces a detailed diff in the error message, indicating:
- Files present in the actual model but not in the signed manifest.
- Files missing from the actual model that were expected in the signed manifest.
- Hash mismatches for files present in both the actual and signed manifests.

Resolves #487 

![image](https://github.com/user-attachments/assets/4306bbbb-2510-43e5-84c2-62efd32b16b8)

##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [x] Release note has been added to CHANGELOG.md if needed

