### PR TITLE
Ignore unsigned files (read and hash all files and filter late)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All versions prior to 1.0.0 are untracked.
 - Implemented public key identifier hash matching for bundle verification
 - Add warning for older verification material formats (e.g., raw public key bytes) during verification, recommending re-signing
 - Added guidance to `README.md` on how to install `model-signing` with PKCS#11 support.
+- cli: Added support for `--ignore_unsigned_files` option
 
 ## [1.0.1] - 2024-04-18
 

--- a/scripts/tests/test-sign-verify
+++ b/scripts/tests/test-sign-verify
@@ -160,6 +160,40 @@ fi
 check_model_name "${sigfile}" "$(basename "${TMPDIR}")"
 
 echo
+echo "Creating a symlink, that is not part of the signature, to make signature verification fail (1)"
+
+echo "foo" > symlinked
+ln -s symlinked symlink
+
+if python -m model_signing \
+	verify certificate \
+	--signature "$(basename "${sigfile}")" \
+	--certificate_chain "${DIR}/keys/certificate/ca-cert.pem" \
+	--ignore-paths "$(basename "${ignorefile}")" \
+	. ; then
+	echo "Error: 'verify certificate' succeeded after new file (symlink) was created"
+	exit 1
+fi
+
+# This should pass when passing --allow_symlinks when hashing all the files
+echo
+echo "Pass signature verification by ignoring any unsigned files or symlinks"
+if ! python -m model_signing \
+	verify certificate \
+	--signature "$(basename "${sigfile}")" \
+	--certificate_chain "${DIR}/keys/certificate/ca-cert.pem" \
+	--ignore-paths "$(basename "${ignorefile}")" \
+	--ignore_unsigned_files \
+	--allow_symlinks \
+	. ; then
+	echo "Error: 'verify certificate' failed with --ignore_unsigned_files while passing --allow_symlinks"
+	exit 1
+fi
+
+
+rm -f symlinked symlink
+
+echo
 echo "Testing 'sign/verify' certificate when in subdir of model directory and using '..'"
 
 rm -f "$(basename "${sigfile}")"
@@ -207,5 +241,72 @@ if [ "${res}" != "${exp}" ]; then
 	exit 1
 fi
 check_model_name "${sigfile}" "$(basename "${TMPDIR}")"
+
+echo
+echo "Creating a symlink, that is not part of the signature, to make signature verification fail (2)"
+
+# Create another symlinked file
+ln -s subdir/symlinked symlink2
+
+echo
+echo "Fail signature verification by NOT ignoring any unsigned (symlinks)"
+if python -m model_signing \
+	verify certificate \
+	--signature "$(basename "${sigfile}")" \
+	--certificate_chain "${DIR}/keys/certificate/ca-cert.pem" \
+	--ignore-paths "$(basename "${ignorefile}")" \
+	--allow_symlinks \
+	. ; then
+	echo "Error: 'verify certificate' succeeded after new file (symlink) was created"
+	exit 1
+fi
+
+echo
+echo "Pass signature verification by ignoring any unsigned files"
+if ! python -m model_signing \
+	verify certificate \
+	--signature "$(basename "${sigfile}")" \
+	--certificate_chain "${DIR}/keys/certificate/ca-cert.pem" \
+	--ignore-paths "$(basename "${ignorefile}")" \
+	--allow_symlinks \
+	--ignore_unsigned_files \
+	. ; then
+	echo "Error: 'verify certificate' failed with --ignore_unsigned_files to ignore symlink"
+	exit 1
+fi
+
+rm symlink2
+
+# Create a simple new file
+echo
+echo "Creating a regular file that is not part of the signature"
+touch newfile
+
+echo
+echo "Fail signature verification by NOT ignoring any unsigned files (symlinks)"
+if python -m model_signing \
+	verify certificate \
+	--signature "$(basename "${sigfile}")" \
+	--certificate_chain "${DIR}/keys/certificate/ca-cert.pem" \
+	--ignore-paths "$(basename "${ignorefile}")" \
+	--allow_symlinks \
+	. ; then
+	echo "Error: 'verify certificate' succeeded after new file was created"
+	exit 1
+fi
+
+echo
+echo "Pass signature verification by ignoring any unsigned files"
+if ! python -m model_signing \
+	verify certificate \
+	--signature "$(basename "${sigfile}")" \
+	--certificate_chain "${DIR}/keys/certificate/ca-cert.pem" \
+	--ignore-paths "$(basename "${ignorefile}")" \
+	--allow_symlinks \
+	--ignore_unsigned_files \
+	. ; then
+	echo "Error: 'verify certificate' failed with --ignore_unsigned_files to ignore regular file"
+	exit 1
+fi
 
 popd 1>/dev/null || exit 1

--- a/src/model_signing/_cli.py
+++ b/src/model_signing/_cli.py
@@ -68,6 +68,14 @@ _ignore_git_paths_option = click.option(
     help="Ignore git-related files when signing or verifying.",
 )
 
+# Decorator for the commonly used option to ignore all unsigned files
+_ignore_unsigned_files_option = click.option(
+    "--ignore_unsigned_files/--no-ignore_unsigned_files",
+    type=bool,
+    show_default=True,
+    help="Ignore all files that were not originally signed.",
+)
+
 # Decorator for the commonly used option to set the path to the private key
 # (when using non-Sigstore PKI).
 _private_key_option = click.option(
@@ -540,6 +548,7 @@ def _verify() -> None:
     required=True,
     help="The expected identity provider (e.g., https://accounts.example.com).",
 )
+@_ignore_unsigned_files_option
 def _verify_sigstore(
     model_path: pathlib.Path,
     signature: pathlib.Path,
@@ -549,6 +558,7 @@ def _verify_sigstore(
     identity: str,
     identity_provider: str,
     use_staging: bool,
+    ignore_unsigned_files: bool,
 ) -> None:
     """Verify using Sigstore (DEFAULT verification method).
 
@@ -572,7 +582,9 @@ def _verify_sigstore(
                 ignore_git_paths=ignore_git_paths,
             )
             .set_allow_symlinks(allow_symlinks)
-        ).verify(model_path, signature)
+        ).set_ignore_unsigned_files(ignore_unsigned_files).verify(
+            model_path, signature
+        )
     except Exception as err:
         click.echo(f"Verification failed with error: {err}", err=True)
         sys.exit(1)
@@ -593,6 +605,7 @@ def _verify_sigstore(
     required=True,
     help="Path to the public key used for verification.",
 )
+@_ignore_unsigned_files_option
 def _verify_private_key(
     model_path: pathlib.Path,
     signature: pathlib.Path,
@@ -600,6 +613,7 @@ def _verify_private_key(
     ignore_git_paths: bool,
     allow_symlinks: bool,
     public_key: pathlib.Path,
+    ignore_unsigned_files: bool,
 ) -> None:
     """Verity using a public key (paired with a private one).
 
@@ -624,7 +638,9 @@ def _verify_private_key(
                 ignore_git_paths=ignore_git_paths,
             )
             .set_allow_symlinks(allow_symlinks)
-        ).verify(model_path, signature)
+        ).set_ignore_unsigned_files(ignore_unsigned_files).verify(
+            model_path, signature
+        )
     except Exception as err:
         click.echo(f"Verification failed with error: {err}", err=True)
         sys.exit(1)
@@ -647,6 +663,7 @@ def _verify_private_key(
     show_default=True,
     help="Log SHA256 fingerprints of all certificates.",
 )
+@_ignore_unsigned_files_option
 def _verify_certificate(
     model_path: pathlib.Path,
     signature: pathlib.Path,
@@ -655,6 +672,7 @@ def _verify_certificate(
     allow_symlinks: bool,
     certificate_chain: Iterable[pathlib.Path],
     log_fingerprints: bool,
+    ignore_unsigned_files: bool,
 ) -> None:
     """Verify using a certificate.
 
@@ -683,7 +701,9 @@ def _verify_certificate(
                 ignore_git_paths=ignore_git_paths,
             )
             .set_allow_symlinks(allow_symlinks)
-        ).verify(model_path, signature)
+        ).set_ignore_unsigned_files(ignore_unsigned_files).verify(
+            model_path, signature
+        )
     except Exception as err:
         click.echo(f"Verification failed with error: {err}", err=True)
         sys.exit(1)

--- a/src/model_signing/manifest.py
+++ b/src/model_signing/manifest.py
@@ -442,6 +442,9 @@ class Manifest:
     def __eq__(self, other: Self):
         return self._item_to_digest == other._item_to_digest
 
+    def __lt__(self, other: Self):
+        return self._item_to_digest.items() < other._item_to_digest.items()
+
     def resource_descriptors(self) -> Iterator[_ResourceDescriptor]:
         """Yields each resource from the manifest, one by one."""
         for item, digest in sorted(self._item_to_digest.items()):


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary

This PR adds support for an option --ignore_unsigned_files to ignore files that are not part of the signature manifest. This allows to for example ignore files that were added after a signature was created. Existing test cases are extended to cover additional symlinks and regular files added after signature created and tests for expected passes and failures depending on whether --ignore_unsigned_files is used.

Compared to PR #501, the implementation in this PR still has all files read and hashed and then ensures that while comparing the files (items) in the `actual_manifest` are not a true subset of the files (items) in the `expected_manifest`. If the `actual_manifest` were a true subset of the `expected_manifest`, this would mean that the `expected_manifest` was missing files.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [X] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [X] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [X] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
