### PR TITLE
feat: enable GitHub annotations for linting

### DIFF
--- a/.github/pytype-problem-matcher.json
+++ b/.github/pytype-problem-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "pytype",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^(.*?):(\\d+):(\\d+):\\s+error: (.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,6 +49,7 @@ jobs:
       run: |
         set -euxo pipefail
         if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+          sudo apt update
           sudo apt install softhsm2 gnutls-bin
           ./scripts/pkcs11-tests/softhsm_setup setup
         fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,6 +79,8 @@ jobs:
           persist-credentials: false
       - name: Set up Hatch
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
+      - name: Register pytype problem matcher
+        run: echo "::add-matcher::$GITHUB_WORKSPACE/.github/pytype-problem-matcher.json"
       - name: Run type check
         run: hatch run type:check
 
@@ -96,3 +98,5 @@ jobs:
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
       - name: Run python linting
         run: hatch fmt --check
+        env:
+          RUFF_OUTPUT_FORMAT: github

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,23 +75,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build Image
-        id: build_image
-        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
-        with:
-          containerfiles: |
-            ./Containerfile
-          image: ghcr.io/sigstore/model-transparency-cli
-          tags: "latest ${{ github.event.release.tag_name }}"
-          archs: amd64
-          oci: false
-
-      - id: docker_meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
-        with:
-          images: ${{ steps.build_image.outputs.image }}
-          tags: type=sha,format=long,type=ref,event=branch
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         id: registry_login
@@ -100,19 +83,72 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push To GHCR
-        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
-        id: push
+      - name: Build minimal image
+        id: build_minimal_image
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
-          image: ${{ steps.build_image.outputs.image }}
-          tags: ${{ steps.build_image.outputs.tags }}
+          containerfiles: |
+            ./Containerfile
+          image: sigstore/model-transparency-cli
+          tags: "${{ github.event.release.tag_name }}-minimal"
+          archs: amd64
+          oci: false
+          build-args: |
+            BUILD_TYPE=minimal
+
+      - id: docker_meta_minimal
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+        with:
+          images: ${{ steps.build_minimal_image.outputs.image }}
+          tags: type=sha,format=long,type=ref,event=branch
+
+      - name: Push minimal image to GHCR
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
+        id: push_minimal
+        with:
+          image: ${{ steps.build_minimal_image.outputs.image }}
+          tags: ${{ steps.build_minimal_image.outputs.tags }}
           registry: ghcr.io
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-name: ghcr.io/sigstore/model-transparency-cli
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ steps.push_minimal.outputs.digest }}
+          push-to-registry: true
+
+      - name: Build full image
+        id: build_full_image
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
+        with:
+          containerfiles: |
+            ./Containerfile
+          image: sigstore/model-transparency-cli
+          tags: "latest ${{ github.event.release.tag_name }}"
+          archs: amd64
+          oci: false
+          build-args: |
+            BUILD_TYPE=full
+
+      - id: docker_meta_full
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+        with:
+          images: ${{ steps.build_full_image.outputs.image }}
+          tags: type=sha,format=long,type=ref,event=branch
+
+      - name: Push full image to GHCR
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
+        id: push_full
+        with:
+          image: ${{ steps.build_full_image.outputs.image }}
+          tags: ${{ steps.build_full_image.outputs.tags }}
+          registry: ghcr.io
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-name: ghcr.io/sigstore/model-transparency-cli
+          subject-digest: ${{ steps.push_full.outputs.digest }}
           push-to-registry: true
 
   # TODO: Create and publish release notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ All versions prior to 1.0.0 are untracked.
 - Implemented public key identifier hash matching for bundle verification
 - Add warning for older verification material formats (e.g., raw public key bytes) during verification, recommending re-signing
 - Added guidance to `README.md` on how to install `model-signing` with PKCS#11 support.
+- Added support trace sigstore sign and verify operations using OpenTelemetry.
+- cli: Added support for `--ignore_unsigned_files` option
+- Implemented a new, minimal container image. This variant excludes optional dependencies (like OTel and PKCS#11) to reduce footprint, focusing solely on core signing and verification mechanisms.
 
 ## [1.0.1] - 2024-04-18
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,61 @@ the PKCS #11 device and store it in a file in PEM format. With can then use:
        --public_key key.pub  /path/to/your/model
 ```
 
+#### OpenTelemetry Support
+
+Model signing supports optional distributed tracing and observability through OpenTelemetry. This allows you to monitor signing operations, track performance, and integrate with observability platforms.
+
+To enable OpenTelemetry support, install the optional dependencies:
+
+```bash
+pip install model-signing[otel]
+```
+
+Once installed, OpenTelemetry will automatically instrument the signing operations. You can configure the telemetry collection using standard OpenTelemetry environment variables:
+
+```bash
+# Configure OTLP endpoint (e.g., Jaeger, Zipkin)
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+
+# Set service name for traces
+export OTEL_SERVICE_NAME=model-signing
+
+# Configure exporters (default: otlp)
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_METRICS_EXPORTER=none
+```
+
+Example with tracing enabled:
+
+```bash
+# Start Jaeger (example using Docker)
+docker run -d --name jaeger \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  jaegertracing/all-in-one:latest
+
+# Sign with tracing
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_SERVICE_NAME=model-signing \
+OTEL_TRACES_EXPORTER=otlp \
+OTEL_METRICS_EXPORTER=none \
+model_signing sign bert-base-uncased
+```
+
+#### Logging Configuration
+
+The `model-signing` CLI supports configurable logging levels to help with debugging and monitoring:
+
+```bash
+# Enable debug logging on the command line
+model_signing --log-level debug sign bert-base-uncased
+
+# Or using environment variable
+MODEL_SIGNING_LOG_LEVEL=debug model_signing sign bert-base-uncased
+```
+
+Available log levels: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`
+
 ### Model Signing API
 
 We offer an API which can be used in integrations with ML frameworks, ML

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,14 @@ keywords = [
 pkcs11 = [
     "PyKCS11",
 ]
+otel = [
+  "opentelemetry-api",
+  "opentelemetry-sdk",
+  "opentelemetry-distro",
+  "opentelemetry-instrumentation",
+  "opentelemetry-instrumentation-urllib3",
+  "opentelemetry-exporter-otlp",
+]
 
 [project.scripts]
 model_signing = "model_signing._cli:main"

--- a/scripts/tests/test-sign-verify
+++ b/scripts/tests/test-sign-verify
@@ -61,7 +61,7 @@ if ! python -m model_signing \
 	--certificate_chain ./keys/certificate/int-ca-cert.pem \
 	--ignore-paths "${ignorefile}" \
 	"${TMPDIR}"; then
-	echo "Error: 'sign key' failed"
+	echo "Error: 'sign certificate' failed"
 	exit 1
 fi
 
@@ -71,7 +71,7 @@ if ! python -m model_signing \
 	--certificate_chain ./keys/certificate/ca-cert.pem \
 	--ignore-paths "${ignorefile}" \
 	"${TMPDIR}"; then
-	echo "Error: 'sign key' failed"
+	echo "Error: 'verify certificate' failed"
 	exit 1
 fi
 
@@ -134,7 +134,7 @@ if ! python -m model_signing \
 	--certificate_chain "${DIR}/keys/certificate/int-ca-cert.pem" \
 	--ignore-paths "$(basename "${ignorefile}")" \
 	. ; then
-	echo "Error: 'sign key' failed"
+	echo "Error: 'sign certificate' failed"
 	exit 1
 fi
 
@@ -144,7 +144,7 @@ if ! python -m model_signing \
 	--certificate_chain "${DIR}/keys/certificate/ca-cert.pem" \
 	--ignore-paths "$(basename "${ignorefile}")" \
 	. ; then
-	echo "Error: 'sign key' failed"
+	echo "Error: 'verify certificate' failed"
 	exit 1
 fi
 
@@ -158,6 +158,40 @@ if [ "${res}" != "${exp}" ]; then
 	exit 1
 fi
 check_model_name "${sigfile}" "$(basename "${TMPDIR}")"
+
+echo
+echo "Creating a symlink, that is not part of the signature, to make signature verification fail (1)"
+
+echo "foo" > symlinked
+ln -s symlinked symlink
+
+if python -m model_signing \
+	verify certificate \
+	--signature "$(basename "${sigfile}")" \
+	--certificate_chain "${DIR}/keys/certificate/ca-cert.pem" \
+	--ignore-paths "$(basename "${ignorefile}")" \
+	. ; then
+	echo "Error: 'verify certificate' succeeded after new file (symlink) was created"
+	exit 1
+fi
+
+# This should pass without having to pass --allow_symlinks since the symlink
+# will be ignored
+echo
+echo "Pass signature verification by ignoring any unsigned files or symlinks"
+if ! python -m model_signing \
+	verify certificate \
+	--signature "$(basename "${sigfile}")" \
+	--certificate_chain "${DIR}/keys/certificate/ca-cert.pem" \
+	--ignore-paths "$(basename "${ignorefile}")" \
+	--ignore_unsigned_files \
+	. ; then
+	echo "Error: 'verify certificate' failed with --ignore_unsigned_files while passing --allow_symlinks"
+	exit 1
+fi
+
+
+rm -f symlinked symlink
 
 echo
 echo "Testing 'sign/verify' certificate when in subdir of model directory and using '..'"
@@ -180,7 +214,7 @@ if ! python -m model_signing \
 	--ignore-paths "../$(basename "${ignorefile}")" \
 	--allow_symlinks \
 	.. ; then
-	echo "Error: 'sign key' failed"
+	echo "Error: 'sign certificate' failed"
 	exit 1
 fi
 
@@ -193,7 +227,7 @@ if ! python -m model_signing \
 	--ignore-paths "$(basename "${ignorefile}")" \
 	--allow_symlinks \
 	. ; then
-	echo "Error: 'sign key' failed"
+	echo "Error: 'verify certificate' failed"
 	exit 1
 fi
 
@@ -207,5 +241,72 @@ if [ "${res}" != "${exp}" ]; then
 	exit 1
 fi
 check_model_name "${sigfile}" "$(basename "${TMPDIR}")"
+
+echo
+echo "Creating a symlink, that is not part of the signature, to make signature verification fail (2)"
+
+# Create another symlinked file
+ln -s subdir/symlinked symlink2
+
+echo
+echo "Fail signature verification by NOT ignoring any unsigned (symlinks)"
+if python -m model_signing \
+	verify certificate \
+	--signature "$(basename "${sigfile}")" \
+	--certificate_chain "${DIR}/keys/certificate/ca-cert.pem" \
+	--ignore-paths "$(basename "${ignorefile}")" \
+	--allow_symlinks \
+	. ; then
+	echo "Error: 'verify certificate' succeeded after new file (symlink) was created"
+	exit 1
+fi
+
+echo
+echo "Pass signature verification by ignoring any unsigned files"
+if ! python -m model_signing \
+	verify certificate \
+	--signature "$(basename "${sigfile}")" \
+	--certificate_chain "${DIR}/keys/certificate/ca-cert.pem" \
+	--ignore-paths "$(basename "${ignorefile}")" \
+	--allow_symlinks \
+	--ignore_unsigned_files \
+	. ; then
+	echo "Error: 'verify certificate' failed with --ignore_unsigned_files to ignore symlink"
+	exit 1
+fi
+
+rm symlink2
+
+# Create a simple new file
+echo
+echo "Creating a regular file that is not part of the signature"
+touch newfile
+
+echo
+echo "Fail signature verification by NOT ignoring any unsigned files (symlinks)"
+if python -m model_signing \
+	verify certificate \
+	--signature "$(basename "${sigfile}")" \
+	--certificate_chain "${DIR}/keys/certificate/ca-cert.pem" \
+	--ignore-paths "$(basename "${ignorefile}")" \
+	--allow_symlinks \
+	. ; then
+	echo "Error: 'verify certificate' succeeded after new file was created"
+	exit 1
+fi
+
+echo
+echo "Pass signature verification by ignoring any unsigned files"
+if ! python -m model_signing \
+	verify certificate \
+	--signature "$(basename "${sigfile}")" \
+	--certificate_chain "${DIR}/keys/certificate/ca-cert.pem" \
+	--ignore-paths "$(basename "${ignorefile}")" \
+	--allow_symlinks \
+	--ignore_unsigned_files \
+	. ; then
+	echo "Error: 'verify certificate' failed with --ignore_unsigned_files to ignore regular file"
+	exit 1
+fi
 
 popd 1>/dev/null || exit 1

--- a/scripts/tests/verify_test.py
+++ b/scripts/tests/verify_test.py
@@ -41,7 +41,7 @@ class TestVerify:
             public_key=public_key
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                paths=list(ignore_paths) + [signature],
+                paths=list(ignore_paths) + [signature.name],
                 ignore_git_paths=ignore_git_paths,
             )
         ).verify(model_path, signature)
@@ -61,7 +61,7 @@ class TestVerify:
             log_fingerprints=log_fingerprints,
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                paths=list(ignore_paths) + [signature],
+                paths=list(ignore_paths) + [signature.name],
                 ignore_git_paths=ignore_git_paths,
             )
         ).verify(model_path, signature)
@@ -83,7 +83,7 @@ class TestVerify:
             use_staging=use_staging,
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                paths=list(ignore_paths) + [signature],
+                paths=list(ignore_paths) + [signature.name],
                 ignore_git_paths=ignore_git_paths,
             )
         ).verify(model_path, signature)
@@ -101,7 +101,7 @@ class TestVerify:
             public_key=public_key
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                paths=list(ignore_paths) + [signature],
+                paths=list(ignore_paths) + [signature.name],
                 ignore_git_paths=ignore_git_paths,
             )
         ).verify(model_path, signature)
@@ -121,7 +121,7 @@ class TestVerify:
             log_fingerprints=log_fingerprints,
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                paths=list(ignore_paths) + [signature],
+                paths=list(ignore_paths) + [signature.name],
                 ignore_git_paths=ignore_git_paths,
             )
         ).verify(model_path, signature)
@@ -143,7 +143,7 @@ class TestVerify:
             use_staging=use_staging,
         ).set_hashing_config(
             model_signing.hashing.Config().set_ignored_paths(
-                paths=list(ignore_paths) + [signature],
+                paths=list(ignore_paths) + [signature.name],
                 ignore_git_paths=ignore_git_paths,
             )
         ).verify(model_path, signature)

--- a/src/model_signing/_serialization/file.py
+++ b/src/model_signing/_serialization/file.py
@@ -76,6 +76,7 @@ class Serializer(serialization.Serializer):
         model_path: pathlib.Path,
         *,
         ignore_paths: Iterable[pathlib.Path] = frozenset(),
+        files_to_hash: Optional[Iterable[pathlib.Path]] = None,
     ) -> manifest.Manifest:
         """Serializes the model given by the `model_path` argument.
 
@@ -84,6 +85,8 @@ class Serializer(serialization.Serializer):
             ignore_paths: The paths to ignore during serialization. If a
               provided path is a directory, all children of the directory are
               ignored.
+            files_to_hash: Optional list of files that are to be hashed;
+              ignore all others
 
         Returns:
             The model's serialized manifest.
@@ -97,7 +100,11 @@ class Serializer(serialization.Serializer):
         # Python3.12 is the minimum supported version, the glob can be replaced
         # with `pathlib.Path.walk` for a clearer interface, and some speed
         # improvement.
-        for path in itertools.chain((model_path,), model_path.glob("**/*")):
+        if files_to_hash is None:
+            files_to_hash = itertools.chain(
+                (model_path,), model_path.glob("**/*")
+            )
+        for path in files_to_hash:
             serialization.check_file_or_directory(
                 path, allow_symlinks=self._allow_symlinks
             )

--- a/src/model_signing/_serialization/file_shard.py
+++ b/src/model_signing/_serialization/file_shard.py
@@ -110,6 +110,7 @@ class Serializer(serialization.Serializer):
         model_path: pathlib.Path,
         *,
         ignore_paths: Iterable[pathlib.Path] = frozenset(),
+        files_to_hash: Optional[Iterable[pathlib.Path]] = None,
     ) -> manifest.Manifest:
         """Serializes the model given by the `model_path` argument.
 
@@ -118,6 +119,8 @@ class Serializer(serialization.Serializer):
             ignore_paths: The paths to ignore during serialization. If a
               provided path is a directory, all children of the directory are
               ignored.
+            files_to_hash: Opitonal list of files that are to be hashed;
+              ignore all others
 
         Returns:
             The model's serialized manifest.
@@ -131,7 +134,11 @@ class Serializer(serialization.Serializer):
         # Python3.12 is the minimum supported version, the glob can be replaced
         # with `pathlib.Path.walk` for a clearer interface, and some speed
         # improvement.
-        for path in itertools.chain((model_path,), model_path.glob("**/*")):
+        if files_to_hash is None:
+            files_to_hash = itertools.chain(
+                (model_path,), model_path.glob("**/*")
+            )
+        for path in files_to_hash:
             serialization.check_file_or_directory(
                 path, allow_symlinks=self._allow_symlinks
             )

--- a/src/model_signing/_signing/sign_certificate.py
+++ b/src/model_signing/_signing/sign_certificate.py
@@ -34,7 +34,7 @@ from model_signing._signing import sign_ec_key as ec_key
 from model_signing._signing import sign_sigstore_pb as sigstore_pb
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class Signer(ec_key.Signer):

--- a/tests/hashing_config_test.py
+++ b/tests/hashing_config_test.py
@@ -1,0 +1,18 @@
+from model_signing import hashing
+
+
+def test_set_ignored_paths_relative_to_model(tmp_path, monkeypatch):
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "ignored.txt").write_text("skip")
+    (model / "keep.txt").write_text("keep")
+
+    cfg = hashing.Config().set_ignored_paths(paths=["ignored.txt"])
+    # Change working directory to ensure ignored paths aren't resolved against
+    # the current directory used at hashing time.
+    monkeypatch.chdir(tmp_path)
+
+    manifest = cfg.hash(model)
+    identifiers = {rd.identifier for rd in manifest.resource_descriptors()}
+    assert "ignored.txt" not in identifiers
+    assert "keep.txt" in identifiers


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
Added a custom problem matcher so pytype emits GitHub annotations for type errors directly in pull requests

Updated the lint workflow to output ruff lint results in GitHub’s annotation format

#### Testing
hatch fmt --check

hatch run type:check

##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed
