### PR TITLE
feat: enable GitHub annotations for linting

### DIFF
--- a/.github/pytype-problem-matcher.json
+++ b/.github/pytype-problem-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "pytype",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^(.*?):(\\d+):(\\d+):\\s+error: (.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,6 +79,8 @@ jobs:
           persist-credentials: false
       - name: Set up Hatch
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
+      - name: Register pytype problem matcher
+        run: echo "::add-matcher::$GITHUB_WORKSPACE/.github/pytype-problem-matcher.json"
       - name: Run type check
         run: hatch run type:check
 
@@ -96,3 +98,5 @@ jobs:
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
       - name: Run python linting
         run: hatch fmt --check
+        env:
+          RUFF_OUTPUT_FORMAT: github


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
Added a custom problem matcher so pytype emits GitHub annotations for type errors directly in pull requests

Updated the lint workflow to output ruff lint results in GitHub’s annotation format

#### Testing
hatch fmt --check

hatch run type:check

##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed
