### PR TITLE
Update serialization metadata when toggling symlink handling

### DIFF
--- a/src/model_signing/_serialization/file.py
+++ b/src/model_signing/_serialization/file.py
@@ -53,6 +53,7 @@ class Serializer(serialization.Serializer):
             allow_symlinks: Controls whether symbolic links are included. If a
               symlink is present but the flag is `False` (default) the
               serialization would raise an error.
+            ignore_paths: The paths of files to ignore.
         """
         self._hasher_factory = file_hasher_factory
         self._max_workers = max_workers
@@ -69,6 +70,10 @@ class Serializer(serialization.Serializer):
     def set_allow_symlinks(self, allow_symlinks: bool) -> None:
         """Set whether following symlinks is allowed."""
         self._allow_symlinks = allow_symlinks
+        hasher = self._hasher_factory(pathlib.Path())
+        self._serialization_description = manifest._FileSerialization(
+            hasher.digest_name, self._allow_symlinks, self._ignore_paths
+        )
 
     @override
     def serialize(

--- a/src/model_signing/_serialization/file_shard.py
+++ b/src/model_signing/_serialization/file_shard.py
@@ -51,7 +51,7 @@ def _endpoints(step: int, end: int) -> Iterable[int]:
 
 
 class Serializer(serialization.Serializer):
-    """Model serializers that produces a manifest recording every file shard.
+    """Model serializer that produces a manifest recording every file shard.
 
     Traverses the model directory and creates digests for every file found,
     sharding the file in equal shards and computing the digests in parallel.
@@ -103,6 +103,13 @@ class Serializer(serialization.Serializer):
     def set_allow_symlinks(self, allow_symlinks: bool) -> None:
         """Set whether following symlinks is allowed."""
         self._allow_symlinks = allow_symlinks
+        hasher = self._hasher_factory(pathlib.Path(), 0, 1)
+        self._serialization_description = manifest._ShardSerialization(
+            hasher._content_hasher.digest_name,
+            self._shard_size,
+            self._allow_symlinks,
+            self._ignore_paths,
+        )
 
     @override
     def serialize(
@@ -119,8 +126,7 @@ class Serializer(serialization.Serializer):
             ignore_paths: The paths to ignore during serialization. If a
               provided path is a directory, all children of the directory are
               ignored.
-            files_to_hash: Opitonal list of files that are to be hashed;
-              ignore all others
+            files_to_hash: Optional list of files to hash; ignore all others
 
         Returns:
             The model's serialized manifest.

--- a/tests/_serialization/file_shard_test.py
+++ b/tests/_serialization/file_shard_test.py
@@ -367,6 +367,12 @@ class TestSerializer:
         ):
             _ = serializer.serialize(symlink_model_folder)
 
+    def test_set_allow_symlinks_updates_manifest(self, sample_model_file):
+        serializer = file_shard.Serializer(self._hasher_factory)
+        serializer.set_allow_symlinks(True)
+        manifest_file = serializer.serialize(sample_model_file)
+        assert manifest_file.serialization_type["allow_symlinks"] is True
+
     def test_shard_to_string(self):
         """Ensure the shard's `__str__` method behaves as assumed."""
         shard = manifest._Shard(pathlib.PurePosixPath("a"), 0, 42)

--- a/tests/_serialization/file_test.py
+++ b/tests/_serialization/file_test.py
@@ -302,6 +302,12 @@ class TestSerializer:
         ):
             _ = serializer.serialize(symlink_model_folder)
 
+    def test_set_allow_symlinks_updates_manifest(self, sample_model_file):
+        serializer = file.Serializer(self._hasher_factory)
+        serializer.set_allow_symlinks(True)
+        manifest = serializer.serialize(sample_model_file)
+        assert manifest.serialization_type["allow_symlinks"] is True
+
     def test_ignore_list_respects_directories(self, sample_model_folder):
         serializer = file.Serializer(self._hasher_factory)
         manifest1 = serializer.serialize(sample_model_folder)


### PR DESCRIPTION
#### Summary

Documented the ignore_paths parameter in the file serializer and ensured symlink policy changes update the recorded serialization metadata

Updated the file-shard serializer to refresh its serialization metadata when toggling symlink handling

Added tests verifying that manifests correctly reflect updated symlink settings for both file and shard serializers
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [X] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
