### PR TITLE
Replace sigstore_proto_buf with sigstore_models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ dependencies = [
   "click",
   "cryptography",
   "in-toto-attestation",
-  "sigstore-protobuf-specs == 0.3.2",
   "sigstore>=4.0",
+  "sigstore-models>=0.0.5",
   "typing_extensions",
 ]
 requires-python = ">=3.9"

--- a/src/model_signing/_signing/sign_certificate.py
+++ b/src/model_signing/_signing/sign_certificate.py
@@ -14,6 +14,7 @@
 
 """Signers and verifiers using certificates."""
 
+import base64
 from collections.abc import Iterable
 import logging
 import pathlib
@@ -26,8 +27,8 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.x509 import oid
 from OpenSSL import crypto
-from sigstore_protobuf_specs.dev.sigstore.bundle import v1 as bundle_pb
-from sigstore_protobuf_specs.dev.sigstore.common import v1 as common_pb
+from sigstore_models.bundle import v1 as bundle_pb
+from sigstore_models.common import v1 as common_pb
 from typing_extensions import override
 
 from model_signing._signing import sign_ec_key as ec_key
@@ -79,8 +80,10 @@ class Signer(ec_key.Signer):
     def _get_verification_material(self) -> bundle_pb.VerificationMaterial:
         def _to_protobuf_certificate(certificate):
             return common_pb.X509Certificate(
-                raw_bytes=certificate.public_bytes(
-                    encoding=serialization.Encoding.DER
+                raw_bytes=base64.b64encode(
+                    certificate.public_bytes(
+                        encoding=serialization.Encoding.DER
+                    )
                 )
             )
 
@@ -95,7 +98,8 @@ class Signer(ec_key.Signer):
         return bundle_pb.VerificationMaterial(
             x509_certificate_chain=common_pb.X509CertificateChain(
                 certificates=chain
-            )
+            ),
+            tlog_entries=[],
         )
 
 


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary

Replace sigstore_proto_buf with sigstore_models. In many cases the classes of sigstore_modelscan be called with unchanged parameters, but in some cases explicit base64 encoding needs to be done.


<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [X] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [X] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
