### PR TITLE
fix: pin sigstore to v3 while working on v4 migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
   "click",
   "cryptography",
   "in-toto-attestation",
-  "sigstore",
+  "sigstore-protobuf-specs == 0.3.2",
+  "sigstore==3.6.5",
   "typing_extensions",
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
Stopgap while debugging #532 

##### Checklist

- [X] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
