### PR TITLE
Remove license classifier.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ authors = [
   { name = "Sigstore Authors", email = "sigstore-dev@googlegroups.com" }
 ]
 classifiers = [
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
#### Summary

These will get deprecated as part of [PEP 639](https://peps.python.org/pep-0639/)

##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code has docstrings and type annotations
- [x] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [x] Public facing changes are paired with documentation changes
- [x] Release note has been added to CHANGELOG.md if needed