### PR TITLE
fix: remove unintended conditional grouping causing overtriggering

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   publish-benchmark-container:
-    if: ${{ github.event_name == 'workflow_dispatch' }} || ${{ (github.event.issue.pull_request) && (startsWith(github.event.comment.body, '/bench')) }}
+    if: github.event_name == 'workflow_dispatch' || (github.event.issue.pull_request && startsWith(github.event.comment.body, '/bench'))
     runs-on: [ubuntu-latest]
     permissions:
       packages: write


### PR DESCRIPTION
#### Summary
Previously testing if an issue comment was a PR and if the comment started with `/bench` were grouped in the same expression and evaluated to true for every PR comment.

The ${{ }} expression syntax is optional in `if` conditionals, so I removed it.  This wasn't caught initially as I always tested with comments that started with `/bench`, and never with a comment that shouldn't have triggered the benchmark.

Relates to #552

##### Checklist

- [X] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
