### PR TITLE
bench: avoid using heredoc in gcloud command

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -97,10 +97,9 @@ jobs:
           workload_identity_provider: projects/306323169285/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
           service_account: 'model-transparency-gha@sigstore-infra-playground.iam.gserviceaccount.com'
       - run: |
+          envsubst '$TAG' < benchmarks/cloud_batch.json > benchmarks/final_config.json
           gcloud batch jobs submit \
             --job-prefix=bench \
             --project sigstore-infra-playground \
             --location us-central1 \
-            --config - <<EOF
-            $(envsubst '$TAG' < benchmarks/cloud_batch.json)
-            EOF
+            --config benchmarks/final_config.json


### PR DESCRIPTION
#### Summary
The GitHub Actions script is complaining about the heredoc, so just get rid of it instead of debugging why:

	warning: here-document at line 5 delimited by end-of-file (wanted `EOF')
	ERROR: (gcloud.batch.jobs.submit) Unable to parse config file: Extra data: line 63 column 3 (char 2012)

##### Checklist

- [X] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
