### PR TITLE
bench: specify service account in Cloud Batch job config

### DIFF
--- a/benchmarks/cloud_batch.json
+++ b/benchmarks/cloud_batch.json
@@ -39,6 +39,9 @@
         }
     ],
     "allocationPolicy": {
+        "serviceAccount": {
+            "email": "model-transparency-gha@sigstore-infra-playground.iam.gserviceaccount.com"
+        },
         "instances": [
             {
                 "policy": {


### PR DESCRIPTION
#### Summary

Specify the correct service account, without specifying an account, the default Compute Engine service account is used:
https://cloud.google.com/batch/docs/create-run-job-custom-service-account

Fixes #552 

##### Checklist

- [X] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
