### PR TITLE
fuzzing: allow fuzzers to choose the serialization method

### DIFF
--- a/tests/fuzzing/fuzz_sign_then_mutate_verify_with_valid_key.py
+++ b/tests/fuzzing/fuzz_sign_then_mutate_verify_with_valid_key.py
@@ -22,6 +22,7 @@ import tempfile
 import atheris  # type: ignore
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
+from utils import _build_hashing_config_from_fdp
 from utils import any_files
 from utils import create_fuzz_files
 from utils import safe_write
@@ -98,8 +99,11 @@ def TestOneInput(data: bytes) -> None:
 
         key_spec = _pick_key_spec(fdp)
 
+        hcfg = _build_hashing_config_from_fdp(fdp)
+
         # Sign the directory root with a valid private key.
         scfg = model_signing.signing.Config()
+        scfg.set_hashing_config(hcfg)
         signer = scfg.use_elliptic_key_signer(private_key=key_spec["priv"])
         _ = signer.sign(model_path, sig_path)
 
@@ -134,6 +138,7 @@ def TestOneInput(data: bytes) -> None:
 
         # Verification must fail with ValueError because the tree changed.
         vcfg = model_signing.verifying.Config()
+        vcfg.set_hashing_config(hcfg)
         verifier = vcfg.use_elliptic_key_verifier(public_key=key_spec["pub"])
         try:
             verifier.verify(model_path, sig_path)

--- a/tests/fuzzing/fuzz_sign_verify_with_valid_key.py
+++ b/tests/fuzzing/fuzz_sign_verify_with_valid_key.py
@@ -23,6 +23,7 @@ import tempfile
 import atheris
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
+from utils import _build_hashing_config_from_fdp
 from utils import any_files
 from utils import create_fuzz_files
 
@@ -98,11 +99,15 @@ def TestOneInput(data: bytes) -> None:
 
         key_spec = _pick_key_spec(fdp)
 
+        hcfg = _build_hashing_config_from_fdp(fdp)
+
         scfg = model_signing.signing.Config()
+        scfg.set_hashing_config(hcfg)
         signer = scfg.use_elliptic_key_signer(private_key=key_spec["priv"])
         _ = signer.sign(model_path, sig_path)
 
         vcfg = model_signing.verifying.Config()
+        vcfg.set_hashing_config(hcfg)
         verifier = vcfg.use_elliptic_key_verifier(public_key=key_spec["pub"])
         verifier.verify(model_path, sig_path)
 

--- a/tests/fuzzing/fuzz_sign_with_invalid_key.py
+++ b/tests/fuzzing/fuzz_sign_with_invalid_key.py
@@ -20,6 +20,7 @@ import tempfile
 # type: ignore
 import atheris
 from cryptography.hazmat.primitives import serialization
+from utils import _build_hashing_config_from_fdp
 from utils import any_files
 from utils import create_fuzz_files
 
@@ -63,7 +64,10 @@ def TestOneInput(data: bytes) -> None:
         model_path = str(root)
         sig_path = os.path.join(sigdir, "model.sig")
 
+        hcfg = _build_hashing_config_from_fdp(fdp)
+
         scfg = model_signing.signing.Config()
+        scfg.set_hashing_config(hcfg)
         signer = scfg.use_elliptic_key_signer(private_key=key_path)
         _ = signer.sign(model_path, sig_path)
 

--- a/tests/fuzzing/fuzz_sign_with_valid_key_verify_with_invalid_key.py
+++ b/tests/fuzzing/fuzz_sign_with_valid_key_verify_with_invalid_key.py
@@ -23,6 +23,7 @@ import tempfile
 import atheris
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
+from utils import _build_hashing_config_from_fdp
 from utils import any_files
 from utils import create_fuzz_files
 
@@ -90,8 +91,11 @@ def TestOneInput(data: bytes) -> None:
         model_path = str(root)
         sig_path = os.path.join(sigdir, "model.sig")
 
+        hcfg = _build_hashing_config_from_fdp(fdp)
+
         # Sign using the valid private key created at module import time.
         scfg = model_signing.signing.Config()
+        scfg.set_hashing_config(hcfg)
         signer = scfg.use_elliptic_key_signer(private_key=_PRIV_PATH)
         _ = signer.sign(model_path, sig_path)
 
@@ -102,6 +106,7 @@ def TestOneInput(data: bytes) -> None:
 
         # Verify with the fuzzed public key.
         vcfg = model_signing.verifying.Config()
+        vcfg.set_hashing_config(hcfg)
         verifier = vcfg.use_elliptic_key_verifier(public_key=pubkey_path)
         verifier.verify(model_path, sig_path)
 

--- a/tests/fuzzing/fuzz_simple_sigstore.py
+++ b/tests/fuzzing/fuzz_simple_sigstore.py
@@ -21,6 +21,7 @@ import tempfile
 # type: ignore
 import atheris
 from sigstore.models import TrustedRoot
+from utils import _build_hashing_config_from_fdp
 from utils import any_files
 from utils import create_fuzz_files
 
@@ -131,7 +132,10 @@ def TestOneInput(data: bytes) -> None:
             fdp.ConsumeBytes(64).decode("utf-8", errors="ignore") or "token"
         )
 
+        hcfg = _build_hashing_config_from_fdp(fdp)
+
         sc = signing.Config()
+        sc.set_hashing_config(hcfg)
         sc.use_sigstore_signer(
             use_staging=True, identity_token=sigstore_oidc_beacon_token
         )
@@ -142,6 +146,7 @@ def TestOneInput(data: bytes) -> None:
 
         # 7) Verify
         vc = verifying.Config()
+        vc.set_hashing_config(hcfg)
         vc.use_sigstore_verifier(
             identity=expected_identity,
             oidc_issuer=expected_oidc_issuer,


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary

This PR allows the fuzzers to choose the serialization method - either file or shard - as well as whether to use sha256, blake2 and blake3. The main goal of the PR is to improve coverage of the fuzzers by improving the configurations they can use.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
