### PR TITLE
(fix): copy only relevant files onto the build stages

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -26,12 +26,18 @@ RUN apt-get update && \
 
 FROM base_builder AS minimal_install
 WORKDIR /app
-COPY . /app
+COPY src /app/src
+COPY pyproject.toml /app/
+COPY README.md /app/
+COPY LICENSE /app/
 RUN pip install .
 
 FROM base_builder AS full_install
 WORKDIR /app
-COPY . /app
+COPY src /app/src
+COPY pyproject.toml /app/
+COPY README.md /app/
+COPY LICENSE /app/
 RUN pip install .[pkcs11,otel]
 
 FROM base AS minimal_image


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->
This PR refactors the Docker build stages so that we only copy the files required to build and install the Python package instead of copying the entire repository. Our current image build pulls in demo/example content that isn’t part of the final deliverable, and that content drags in dependencies which are flagged by scanners.

#### Changes
Narrow copy in builder stages
Instead of COPY . /app, we now do:
```
COPY src /app/src
COPY pyproject.toml /app/
COPY README.md /app/
COPY LICENSE /app/
```

in both minimal_install and full_install.

##### Why

- Fixes the root cause: the root cause was “too much gets copied into the build stage,” not “the project depends on Keras.” Narrowing the build context removes the source of the false-positive CVE.
- Keeps final image small and clean: by only copying the installed artifacts from the builder into the runtime image, we avoid bringing tutorial/example code into the final image.
- Matches packaging intent: Python projects that are meant to be installed usually only need src/ + project metadata. Copying the whole repo is extra and risky.

##### Security Context
- CVEs were detected because the build layer contained files/deps that reference Keras, not because the final image uses that vulnerable code path.
- Mitigation in this PR: remove the non-deliverable content from the build layer so scanners no longer observe that vulnerable dependency in this image.

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
