### PR TITLE
chore: migrate dependabot `allow: versions` to `ignore: versions`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,8 +39,8 @@ updates:
       all:
         patterns:
         - "*"
-    allow:
-      - dependency-name: "pypa/hatch"
-        versions: [ "install" ] # stay on "install" branch
+    ignore:
+      - dependency-name: "pypa/hatch" # ignore everything except "install" branch
+        versions: [ ">0.0", "hatch*", "master", "gh-pages", "workspaces", "dependabot/*", "coverage", "pre-v1", "v1" ]
       - dependency-name: "github/codeql-action"
-        versions: [ ">=4.0.0" ] # stay on "v4" tag (and "v5" in the future)
+        versions: [ "<4.0.0" ] # ignore all non-numerical tags, and old versions < 4


### PR DESCRIPTION
### Chores
- dependabot changed the schema to not allow `allow: versions` anymore, so I tried to migrate to `ignore: versions`

<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

It seems Dependabot removed the nice `allow: versions` key, so I tried to migrate those simple allow rules to complicated ignore rules :/
If you can, trigger dependabot manually or validate the new configuration in the GitHub UI.

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
