### PR TITLE
Add configurable exclusion of attestation files from model signatures

### DIFF
--- a/docs/demo.ipynb
+++ b/docs/demo.ipynb
@@ -1093,7 +1093,7 @@
       "outputs": [],
       "source": [
         "hashing_config = model_signing.hashing.Config().set_ignored_paths(\n",
-        "    paths=[\"README.md\"], ignore_git_paths=True\n",
+        "    paths=[\"README.md\"], ignore_git_paths=True, ignore_att_paths=True\n",
         ")"
       ]
     },

--- a/docs/model_signing_format.md
+++ b/docs/model_signing_format.md
@@ -66,6 +66,10 @@ library after passing it an In-Toto Statement. This API will sign the statement,
 producing a DSSE envelope, along with a DSSE log entry that is submitted to the
 transparency log.
 
+## Excluded Files
+
+Signature and attestation files are automatically excluded from the model signature to allow attestations (SLSA provenance, SBOMs, etc.) to accumulate independently throughout a model's lifecycle. Excluded patterns include `*.sig`, `*.sigstore.json`, and `claims.jsonl`.
+
 ## Example Format
 
 Below is an example of the Sigstore bundle showing each of the layers described above.

--- a/src/model_signing/__init__.py
+++ b/src/model_signing/__init__.py
@@ -53,14 +53,14 @@ model_signing.signing.Config().use_elliptic_key_signer(
     private_key="key"
 ).set_hashing_config(
     model_signing.hashing.Config().set_ignored_paths(
-        paths=["README.md"], ignore_git_paths=True
+        paths=["README.md"], ignore_git_paths=True, ignore_att_paths=True
     )
 ).sign("finbert", "finbert.sig")
 ```
 
 This example generates a signature using a private key based on elliptic curve
-cryptography. It also hashes the model by ignoring `README.md` and any git
-related file present in the model directory.
+cryptography. It also hashes the model by ignoring `README.md`, any git-related
+files, and attestation files present in the model directory.
 
 We also support signing with signing certificates, using a similar API as above.
 

--- a/src/model_signing/_cli.py
+++ b/src/model_signing/_cli.py
@@ -93,6 +93,18 @@ _ignore_git_paths_option = click.option(
     help="Ignore git-related files when signing or verifying.",
 )
 
+# Decorator for the commonly used option to ignore attestation files
+_ignore_att_paths_option = click.option(
+    "--ignore-att-paths/--no-ignore-att-paths",
+    type=bool,
+    default=True,
+    show_default=True,
+    help=(
+        "Ignore signature and attestation files "
+        "(*.sig, *.sigstore.json, claims.jsonl)."
+    ),
+)
+
 # Decorator for the commonly used option to ignore all unsigned files
 _ignore_unsigned_files_option = click.option(
     "--ignore_unsigned_files/--no-ignore_unsigned_files",
@@ -282,6 +294,7 @@ def _sign() -> None:
 @_model_path_argument
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_ignore_att_paths_option
 @_allow_symlinks_option
 @_write_signature_option
 @_sigstore_staging_option
@@ -326,6 +339,7 @@ def _sign_sigstore(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    ignore_att_paths: bool,
     allow_symlinks: bool,
     signature: pathlib.Path,
     use_ambient_credentials: bool,
@@ -388,7 +402,9 @@ def _sign_sigstore(
             ).set_hashing_config(
                 model_signing.hashing.Config()
                 .set_ignored_paths(
-                    paths=ignored, ignore_git_paths=ignore_git_paths
+                    paths=ignored,
+                    ignore_git_paths=ignore_git_paths,
+                    ignore_att_paths=ignore_att_paths,
                 )
                 .set_allow_symlinks(allow_symlinks)
             ).sign(model_path, signature)
@@ -403,6 +419,7 @@ def _sign_sigstore(
 @_model_path_argument
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_ignore_att_paths_option
 @_allow_symlinks_option
 @_write_signature_option
 @_private_key_option
@@ -416,6 +433,7 @@ def _sign_private_key(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    ignore_att_paths: bool,
     allow_symlinks: bool,
     signature: pathlib.Path,
     private_key: pathlib.Path,
@@ -442,7 +460,11 @@ def _sign_private_key(
             private_key=private_key, password=password
         ).set_hashing_config(
             model_signing.hashing.Config()
-            .set_ignored_paths(paths=ignored, ignore_git_paths=ignore_git_paths)
+            .set_ignored_paths(
+                paths=ignored,
+                ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=ignore_att_paths,
+            )
             .set_allow_symlinks(allow_symlinks)
         ).sign(model_path, signature)
     except Exception as err:
@@ -456,6 +478,7 @@ def _sign_private_key(
 @_model_path_argument
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_ignore_att_paths_option
 @_allow_symlinks_option
 @_write_signature_option
 @_pkcs11_uri_option
@@ -463,6 +486,7 @@ def _sign_pkcs11_key(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    ignore_att_paths: bool,
     allow_symlinks: bool,
     signature: pathlib.Path,
     pkcs11_uri: str,
@@ -488,7 +512,11 @@ def _sign_pkcs11_key(
             pkcs11_uri=pkcs11_uri
         ).set_hashing_config(
             model_signing.hashing.Config()
-            .set_ignored_paths(paths=ignored, ignore_git_paths=ignore_git_paths)
+            .set_ignored_paths(
+                paths=ignored,
+                ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=ignore_att_paths,
+            )
             .set_allow_symlinks(allow_symlinks)
         ).sign(model_path, signature)
     except Exception as err:
@@ -502,6 +530,7 @@ def _sign_pkcs11_key(
 @_model_path_argument
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_ignore_att_paths_option
 @_allow_symlinks_option
 @_write_signature_option
 @_private_key_option
@@ -511,6 +540,7 @@ def _sign_certificate(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    ignore_att_paths: bool,
     allow_symlinks: bool,
     signature: pathlib.Path,
     private_key: pathlib.Path,
@@ -543,7 +573,11 @@ def _sign_certificate(
             certificate_chain=certificate_chain,
         ).set_hashing_config(
             model_signing.hashing.Config()
-            .set_ignored_paths(paths=ignored, ignore_git_paths=ignore_git_paths)
+            .set_ignored_paths(
+                paths=ignored,
+                ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=ignore_att_paths,
+            )
             .set_allow_symlinks(allow_symlinks)
         ).sign(model_path, signature)
     except Exception as err:
@@ -557,6 +591,7 @@ def _sign_certificate(
 @_model_path_argument
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_ignore_att_paths_option
 @_allow_symlinks_option
 @_write_signature_option
 @_pkcs11_uri_option
@@ -566,6 +601,7 @@ def _sign_pkcs11_certificate(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    ignore_att_paths: bool,
     allow_symlinks: bool,
     signature: pathlib.Path,
     pkcs11_uri: str,
@@ -599,7 +635,11 @@ def _sign_pkcs11_certificate(
             certificate_chain=certificate_chain,
         ).set_hashing_config(
             model_signing.hashing.Config()
-            .set_ignored_paths(paths=ignored, ignore_git_paths=ignore_git_paths)
+            .set_ignored_paths(
+                paths=ignored,
+                ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=ignore_att_paths,
+            )
             .set_allow_symlinks(allow_symlinks)
         ).sign(model_path, signature)
     except Exception as err:
@@ -637,6 +677,7 @@ def _verify() -> None:
 @_read_signature_option
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_ignore_att_paths_option
 @_allow_symlinks_option
 @_sigstore_staging_option
 @_trust_config_option
@@ -660,6 +701,7 @@ def _verify_sigstore(
     signature: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    ignore_att_paths: bool,
     allow_symlinks: bool,
     identity: str,
     identity_provider: str,
@@ -696,7 +738,9 @@ def _verify_sigstore(
             ).set_hashing_config(
                 model_signing.hashing.Config()
                 .set_ignored_paths(
-                    paths=ignored, ignore_git_paths=ignore_git_paths
+                    paths=ignored,
+                    ignore_git_paths=ignore_git_paths,
+                    ignore_att_paths=ignore_att_paths,
                 )
                 .set_allow_symlinks(allow_symlinks)
             ).set_ignore_unsigned_files(ignore_unsigned_files).verify(
@@ -714,6 +758,7 @@ def _verify_sigstore(
 @_read_signature_option
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_ignore_att_paths_option
 @_allow_symlinks_option
 @click.option(
     "--public_key",
@@ -728,6 +773,7 @@ def _verify_private_key(
     signature: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    ignore_att_paths: bool,
     allow_symlinks: bool,
     public_key: pathlib.Path,
     ignore_unsigned_files: bool,
@@ -753,7 +799,11 @@ def _verify_private_key(
             public_key=public_key
         ).set_hashing_config(
             model_signing.hashing.Config()
-            .set_ignored_paths(paths=ignored, ignore_git_paths=ignore_git_paths)
+            .set_ignored_paths(
+                paths=ignored,
+                ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=ignore_att_paths,
+            )
             .set_allow_symlinks(allow_symlinks)
         ).set_ignore_unsigned_files(ignore_unsigned_files).verify(
             model_path, signature
@@ -770,6 +820,7 @@ def _verify_private_key(
 @_read_signature_option
 @_ignore_paths_option
 @_ignore_git_paths_option
+@_ignore_att_paths_option
 @_allow_symlinks_option
 @_certificate_root_of_trust_option
 @click.option(
@@ -786,6 +837,7 @@ def _verify_certificate(
     signature: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
     ignore_git_paths: bool,
+    ignore_att_paths: bool,
     allow_symlinks: bool,
     certificate_chain: Iterable[pathlib.Path],
     log_fingerprints: bool,
@@ -816,7 +868,11 @@ def _verify_certificate(
             log_fingerprints=log_fingerprints,
         ).set_hashing_config(
             model_signing.hashing.Config()
-            .set_ignored_paths(paths=ignored, ignore_git_paths=ignore_git_paths)
+            .set_ignored_paths(
+                paths=ignored,
+                ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=ignore_att_paths,
+            )
             .set_allow_symlinks(allow_symlinks)
         ).set_ignore_unsigned_files(ignore_unsigned_files).verify(
             model_path, signature

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -200,6 +200,7 @@ class TestKeySigning:
             hashing.Config().set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=False,
             )
         ).sign(model_path, signature)
 
@@ -211,6 +212,7 @@ class TestKeySigning:
             hashing.Config().set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=False,
             )
         ).verify(model_path, signature)
 
@@ -232,6 +234,7 @@ class TestKeySigning:
             hashing.Config().set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=False,
             )
         ).sign(model_path, signature)
 
@@ -267,6 +270,7 @@ class TestCertificateSigning:
             hashing.Config().set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=False,
             )
         ).sign(model_path, signature)
 
@@ -279,6 +283,7 @@ class TestCertificateSigning:
             hashing.Config().set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=False,
             )
         ).verify(model_path, signature)
 
@@ -302,6 +307,7 @@ class TestCertificateSigning:
             hashing.Config().set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=False,
             )
         ).sign(model_path, signature)
 
@@ -336,6 +342,7 @@ class TestCertificateSigning:
             .set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=False,
             )
             .use_shard_serialization()
         ).sign(model_path, signature)
@@ -349,6 +356,7 @@ class TestCertificateSigning:
             hashing.Config().set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=False,
             )
         )
         # .verify(model_path, signature)
@@ -374,6 +382,7 @@ class TestCertificateSigning:
             .set_ignored_paths(
                 paths=list(ignore_paths) + [signature],
                 ignore_git_paths=ignore_git_paths,
+                ignore_att_paths=False,
             )
             .use_shard_serialization()
         ).sign(model_path, signature)


### PR DESCRIPTION
Adds support for excluding attestation files (signature and attestation bundle files) from model signatures by default, addressing #586.

## Changes

- Attestation files (`*.sig`, `*.sigstore.json`, `claims.jsonl`) are now excluded from model signatures by default
- New `--ignore-att-paths` / `--no-ignore-att-paths` CLI flag to control this behavior
- New `ignore_att_paths` parameter in the hashing API
- Updated documentation and tests

## Rationale

Per #586, attestation files should be signed independently to allow attestations to accumulate throughout a model's lifecycle without invalidating the original signature. This is especially important when using the `claims.jsonl` pattern where attestations are appended over time.

The exclusion is enabled by default but can be disabled for edge cases where users need different behavior.

Related: ossf/model-signing-spec#4