### PR TITLE
fix: standardize CLI flags to use hyphens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All versions prior to 1.0.0 are untracked.
 -Added the `digest` subcommand to compute and print a model's digest. This enables other tools to easily pair the attestations with a model directory.
 
 ### Changed
-- ...
+- Standardized CLI flags to use hyphens (e.g., `--trust-config` instead of `--trust_config`). Underscore variants are still accepted for backwards compatibility via token normalization.
 
 ### Fixed
 - Fixed a bug where ignored symlinks could raise `ValueError`s if allow_symlinks was unset, even though they were skipped during serialization. ([#550](https://github.com/sigstore/model-transparency/pull/550))

--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ The digest subcommand follows the same ignore rules used when signing.
 
 ## Using Private Sigstore Instances
 
-To use a private Sigstore setup (e.g. custom Rekor/Fulcio), use the `--trust_config` flag:
+To use a private Sigstore setup (e.g. custom Rekor/Fulcio), use the `--trust-config` flag:
 
 ```bash
-[...]$ model_signing sign bert-base-uncased --trust_config client_trust_config.json
+[...]$ model_signing sign bert-base-uncased --trust-config client_trust_config.json
 ```
 
 For verification:
@@ -138,9 +138,9 @@ For verification:
 ```bash
 [...]$ model_signing verify bert-base-uncased \
       --signature model.sig \
-      --trust_config client_trust_config.json
+      --trust-config client_trust_config.json
       --identity "$identity"
-      --identity_provider "$oidc_provider"
+      --identity-provider "$oidc_provider"
 ```
 
 The `client_trust_config.json` file should include:
@@ -162,7 +162,7 @@ generate the key pair:
 And then we use the private key to sign.
 
 ```bash
-[...]$ model_signing sign key bert-base-uncased --private_key key.priv
+[...]$ model_signing sign key bert-base-uncased --private-key key.priv
 ```
 
 All signing methods support changing the signature name and location via the
@@ -182,7 +182,7 @@ model we use
 [...]$ model_signing verify bert-base-uncased \
       --signature model.sig \
       --identity "$identity" \
-      --identity_provider "$oidc_provider"
+      --identity-provider "$oidc_provider"
 ```
 
 Where `$identity` and `$oidc_provider` are those set up during the signing flow
@@ -210,7 +210,7 @@ Similarly, for key verification, we can use
 
 ```bash
 [...]$ model_signing verify key bert-base-uncased \
-       --signature resnet.sig --public_key key.pub
+       --signature resnet.sig --public-key key.pub
 ```
 
 #### Signing with PKCS #11 URIs
@@ -252,7 +252,7 @@ the PKCS #11 device and store it in a file in PEM format. With can then use:
 
 ```bash
 [...]$ model_signing verify key --signature model.sig\
-       --public_key key.pub  /path/to/your/model
+       --public-key key.pub  /path/to/your/model
 ```
 
 #### OpenTelemetry Support

--- a/src/model_signing/_cli.py
+++ b/src/model_signing/_cli.py
@@ -69,7 +69,7 @@ _read_signature_option = click.option(
 
 # Decorator for the commonly used option for the custom trust configuration.
 _trust_config_option = click.option(
-    "--trust_config",
+    "--trust-config",
     type=pathlib.Path,
     metavar="TRUST_CONFIG_PATH",
     help="The client trust configuration to use",
@@ -95,7 +95,7 @@ _ignore_git_paths_option = click.option(
 
 # Decorator for the commonly used option to ignore all unsigned files
 _ignore_unsigned_files_option = click.option(
-    "--ignore_unsigned_files/--no-ignore_unsigned_files",
+    "--ignore-unsigned-files/--no-ignore-unsigned-files",
     type=bool,
     show_default=True,
     help="Ignore all files that were not originally signed.",
@@ -104,7 +104,7 @@ _ignore_unsigned_files_option = click.option(
 # Decorator for the commonly used option to set the path to the private key
 # (when using non-Sigstore PKI).
 _private_key_option = click.option(
-    "--private_key",
+    "--private-key",
     type=pathlib.Path,
     metavar="PRIVATE_KEY",
     required=True,
@@ -113,7 +113,7 @@ _private_key_option = click.option(
 
 # Decorator for the commonly used option to set a PKCS #11 URI
 _pkcs11_uri_option = click.option(
-    "--pkcs11_uri",
+    "--pkcs11-uri",
     type=str,
     metavar="PKCS11_URI",
     required=True,
@@ -123,7 +123,7 @@ _pkcs11_uri_option = click.option(
 # Decorator for the commonly used option to pass a certificate chain to
 # establish root of trust (when signing or verifying using certificates).
 _certificate_root_of_trust_option = click.option(
-    "--certificate_chain",
+    "--certificate-chain",
     type=pathlib.Path,
     metavar="CERTIFICATE_PATH",
     multiple=True,
@@ -133,7 +133,7 @@ _certificate_root_of_trust_option = click.option(
 
 # Decorator for the commonly used option to use Sigstore's staging instance.
 _sigstore_staging_option = click.option(
-    "--use_staging",
+    "--use-staging",
     type=bool,
     is_flag=True,
     help="Use Sigstore's staging instance.",
@@ -141,7 +141,7 @@ _sigstore_staging_option = click.option(
 
 # Decorator for the commonly used option to pass the signing key's certificate
 _signing_certificate_option = click.option(
-    "--signing_certificate",
+    "--signing-certificate",
     type=pathlib.Path,
     metavar="CERTIFICATE_PATH",
     required=True,
@@ -150,7 +150,7 @@ _signing_certificate_option = click.option(
 
 # Decorator for the commonly used option to allow symlinks
 _allow_symlinks_option = click.option(
-    "--allow_symlinks",
+    "--allow-symlinks",
     is_flag=True,
     help="Whether to allow following symlinks when signing or verifying files.",
 )
@@ -216,7 +216,10 @@ class _PKICmdGroup(click.Group):
 
 
 @click.group(
-    context_settings=dict(help_option_names=["-h", "--help"]),
+    context_settings=dict(
+        help_option_names=["-h", "--help"],
+        token_normalize_func=lambda x: x.replace("_", "-"),
+    ),
     epilog=(
         "Check https://sigstore.github.io/model-transparency for "
         "documentation and more details."
@@ -332,13 +335,13 @@ def _sign() -> None:
 @_sigstore_staging_option
 @_trust_config_option
 @click.option(
-    "--use_ambient_credentials",
+    "--use-ambient-credentials",
     type=bool,
     is_flag=True,
     help="Use credentials from ambient environment.",
 )
 @click.option(
-    "--identity_token",
+    "--identity-token",
     type=str,
     metavar="TOKEN",
     help=(
@@ -347,7 +350,7 @@ def _sign() -> None:
     ),
 )
 @click.option(
-    "--oauth_force_oob",
+    "--oauth-force-oob",
     is_flag=True,
     default=False,
     help=(
@@ -356,13 +359,13 @@ def _sign() -> None:
     ),
 )
 @click.option(
-    "--client_id",
+    "--client-id",
     type=str,
     metavar="ID",
     help="The custom OpenID Connect client ID to use during OAuth2",
 )
 @click.option(
-    "--client_secret",
+    "--client-secret",
     type=str,
     metavar="SECRET",
     help="The custom OpenID Connect client secret to use during OAuth2",
@@ -391,20 +394,20 @@ def _sign_sigstore(
     taken from an interactive OIDC flow, but ambient credentials could be used
     to use workload identity tokens (e.g., when running in GitHub actions).
     Alternatively, a constant identity token can be provided via
-    `--identity_token`.
+    `--identity-token`.
 
     Sigstore allows users to use a staging instance for test-only signatures.
-    Passing the `--use_staging` flag would use that instance instead of the
+    Passing the `--use-staging` flag would use that instance instead of the
     production one.
 
     Additionally, you can specify a custom trust configuration JSON file using
-    the `--trust_config` flag. This allows you to fully customize the PKI
+    the `--trust-config` flag. This allows you to fully customize the PKI
     (Private Key Infrastructure) used in the signing process. By providing a
-    `--trust_config`, you can define your own transparency logs, certificate
+    `--trust-config`, you can define your own transparency logs, certificate
     authorities, and other trust settings, enabling full control over the
     trust model, including which PKI to use for signature verification.
 
-    If `--trust_config` is not provided, the default Sigstore instance is
+    If `--trust-config` is not provided, the default Sigstore instance is
     used, which is pre-configured with Sigstore’s own trusted transparency
     logs and certificate authorities. This provides a ready-to-use default
     trust model for most use cases but may not be suitable for custom or
@@ -668,7 +671,7 @@ def _verify() -> None:
     subcommand).
 
     To enable verification with custom PKI configurations, use the
-    `--trust_config` option. This allows you to specify your own set of trusted
+    `--trust-config` option. This allows you to specify your own set of trusted
     public keys, transparency logs, and certificate authorities for verifying
     the signature. If not provided, the default Sigstore instance and its
     associated public keys, logs, and authorities are used.
@@ -693,7 +696,7 @@ def _verify() -> None:
     help="The expected identity of the signer (e.g., name@example.com).",
 )
 @click.option(
-    "--identity_provider",
+    "--identity-provider",
     type=str,
     metavar="IDENTITY_PROVIDER",
     required=True,
@@ -761,7 +764,7 @@ def _verify_sigstore(
 @_ignore_git_paths_option
 @_allow_symlinks_option
 @click.option(
-    "--public_key",
+    "--public-key",
     type=pathlib.Path,
     metavar="PUBLIC_KEY",
     required=True,
@@ -818,7 +821,7 @@ def _verify_private_key(
 @_allow_symlinks_option
 @_certificate_root_of_trust_option
 @click.option(
-    "--log_fingerprints",
+    "--log-fingerprints",
     type=bool,
     is_flag=True,
     default=False,


### PR DESCRIPTION
#### Summary

Use hyphens instead of underscores for all CLI flags (e.g., --trust-config instead of --trust_config). Underscore variants still accepted via token_normalize_func for backwards compatibility.

I noticed a bunch of inconsistencies, using hyphens strictly going forward would be most consistent imo but I do not mind if we standardize across underscores. Biggest issues found were the following inconsistent commands

1. `"--ignore-git-paths/--no-ignore-git-paths"` (inconsistent with the command below which is near identical)
2. `"--ignore_unsigned_files/--no-ignore_unsigned_files"` (hyphens mixed with underscores)
etc etc

<!-- Thanks for opening a pull request! Please do not just delete this text. -->

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [x] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
