### PR TITLE
lint: prevent CLI flags with underscores

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -100,3 +100,20 @@ jobs:
         run: hatch fmt --check
         env:
           RUFF_OUTPUT_FORMAT: github
+
+  cli-flag-lint:
+    runs-on: ubuntu-latest
+    name: CLI Lint
+    permissions:
+      contents: read
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - name: Check for CLI flags with underscores
+        run: |
+          if grep --recursive --line-number --extended-regexp --include="*.py" '"--[a-zA-Z0-9-]+_[a-zA-Z0-9-]+' src; then
+             echo "::error::Found CLI flags with underscores. Please use dashes."
+             exit 1
+          fi


### PR DESCRIPTION
#### Summary
Expands on #600 to prevent new flags from appearing with underscores.

You can see an example of what a failure looks like here:

https://github.com/sigstore/model-transparency/actions/runs/21076618741/job/60620004277

##### Checklist

- [X] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
