### PR TITLE
chore: move cli tests to hatch environment

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -31,12 +31,13 @@ defaults:
 jobs:
   model-signing-cli-test:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Set up Hatch
+      uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc # install
     - name: Run CLI tests
-      run: |
-        # TODO: this should use hatch
-        python -m venv venv
-        . venv/bin/activate
-        pip install -e .[pkcs11]
-        ./scripts/tests/testrunner
+      run: hatch run cli:test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,17 @@ format-fix = "ruff format src/"
 lint-check = "ruff check src/"
 lint-fix = "ruff check --fix src/"
 
+[tool.hatch.envs.cli]
+description = """Custom environment for CLI tests.
+Use `hatch run cli:test` to run CLI tests.
+"""
+features = [
+    "pkcs11",
+]
+
+[tool.hatch.envs.cli.scripts]
+test = "bash ./scripts/tests/testrunner"
+
 [tool.coverage.report]
 exclude_also = [
   "pass",


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary

Moving cli tests to it's own hatch env, easier to run locally to verify code didn't break backwards compat.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
