### PR TITLE
fix: lazily create OIDC Issuer to support Kubernetes tokens

### DIFF
--- a/src/model_signing/_signing/sign_sigstore.py
+++ b/src/model_signing/_signing/sign_sigstore.py
@@ -126,7 +126,8 @@ class Signer(signing.Signer):
         if not oidc_issuer:
             oidc_issuer = trust_config.signing_config.get_oidc_url()
 
-        self._issuer = sigstore_oidc.Issuer(oidc_issuer)
+        self._oidc_issuer = oidc_issuer
+        self._issuer: sigstore_oidc.Issuer | None = None
         self._signing_context = (
             sigstore_signer.SigningContext.from_trust_config(trust_config)
         )
@@ -152,6 +153,9 @@ class Signer(signing.Signer):
             token = sigstore_oidc.detect_credential(self._client_id)
             if token:
                 return sigstore_oidc.IdentityToken(token, self._client_id)
+
+        if self._issuer is None:
+            self._issuer = sigstore_oidc.Issuer(self._oidc_issuer)
 
         return self._issuer.identity_token(
             force_oob=self._force_oob,


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->
#### Summary

Issuer was created early in `__init__`, fetching OIDC discovery config. Kubernetes OIDC providers lack authorization_endpoint/token_endpoint, causing failures even when identity_token was provided directly.

```
Signing failed with error: OIDC issuer returned invalid configuration: 2 validation errors for _OpenIDConfiguration
authorization_endpoint
  Field required [type=missing, input_value={'issuer': 'https://rh-oi/...', 'iat', 'iss', 'sub']}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
token_endpoint
  Field required [type=missing, input_value={'issuer': 'https://rh-oi/...', 'iat', 'iss', 'sub']}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
 ```

Now Issuer is only created when OAuth flow is needed, after FIRST checking if OIDC token was supplied directly via args, or env.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
