### PR TITLE
fix: pkcs cert chain crash + b64 encode cert in bundle + missing tlog entry

### DIFF
--- a/src/model_signing/_signing/sign_certificate.py
+++ b/src/model_signing/_signing/sign_certificate.py
@@ -72,8 +72,11 @@ class Signer(ec_key.Signer):
                 "the public key paired with the private key"
             )
 
-        self._trust_chain = x509.load_pem_x509_certificates(
-            b"".join([path.read_bytes() for path in certificate_chain_paths])
+        chain_bytes = b"".join(
+            [path.read_bytes() for path in certificate_chain_paths]
+        )
+        self._trust_chain = (
+            x509.load_pem_x509_certificates(chain_bytes) if chain_bytes else []
         )
 
     @override

--- a/src/model_signing/_signing/sign_pkcs11.py
+++ b/src/model_signing/_signing/sign_pkcs11.py
@@ -244,16 +244,21 @@ class CertSigner(Signer):
                 "the public key paired with the private key"
             )
 
-        self._trust_chain = x509.load_pem_x509_certificates(
-            b"".join([path.read_bytes() for path in certificate_chain_paths])
+        chain_bytes = b"".join(
+            [path.read_bytes() for path in certificate_chain_paths]
+        )
+        self._trust_chain = (
+            x509.load_pem_x509_certificates(chain_bytes) if chain_bytes else []
         )
 
     @override
     def _get_verification_material(self) -> bundle_pb.VerificationMaterial:
         def _to_protobuf_certificate(certificate):
             return common_pb.X509Certificate(
-                raw_bytes=certificate.public_bytes(
-                    encoding=serialization.Encoding.DER
+                raw_bytes=base64.b64encode(
+                    certificate.public_bytes(
+                        encoding=serialization.Encoding.DER
+                    )
                 )
             )
 
@@ -268,5 +273,6 @@ class CertSigner(Signer):
         return bundle_pb.VerificationMaterial(
             x509_certificate_chain=common_pb.X509CertificateChain(
                 certificates=chain
-            )
+            ),
+            tlog_entries=[],
         )


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->
This PR addresses bug fixes for the following issues:
- https://github.com/sigstore/model-transparency/issues/613 
- https://github.com/sigstore/model-transparency/issues/614

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
