### PR TITLE
feat: add RFC 3161 Timestamp Authority support for PKI signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All versions prior to 1.0.0 are untracked.
 ## [Unreleased]
 
 ### Added
--Added the `digest` subcommand to compute and print a model's digest. This enables other tools to easily pair the attestations with a model directory.
+- Added the `digest` subcommand to compute and print a model's digest. This enables other tools to easily pair the attestations with a model directory.
+- Added `--tsa-url` option for RFC 3161 timestamps in PKI signing methods.
 
 ### Changed
 - Standardized CLI flags to use hyphens (e.g., `--trust-config` instead of `--trust_config`). Underscore variants are still accepted for backwards compatibility via token normalization.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ And then we use the private key to sign.
 [...]$ model_signing sign key bert-base-uncased --private-key key.priv
 ```
 
+#### Timestamp Authority Support
+
+PKI signing methods support RFC 3161 timestamps via `--tsa-url`:
+
+```bash
+[...]$ model_signing sign key bert-base-uncased --private-key key.priv \
+       --tsa-url https://timestamp.sigstore.dev/api/v1/timestamp
+```
+
 All signing methods support changing the signature name and location via the
 `--signature` flag:
 

--- a/src/model_signing/_cli.py
+++ b/src/model_signing/_cli.py
@@ -155,6 +155,14 @@ _allow_symlinks_option = click.option(
     help="Whether to allow following symlinks when signing or verifying files.",
 )
 
+# Decorator for the commonly used option to set a TSA URL for PKI signing
+_tsa_url_option = click.option(
+    "--tsa-url",
+    type=str,
+    metavar="TSA_URL",
+    help="URL of an RFC 3161 Timestamp Authority for trusted timestamps.",
+)
+
 
 def _resolve_ignore_paths(
     model_path: pathlib.Path, paths: Iterable[pathlib.Path]
@@ -454,6 +462,7 @@ def _sign_sigstore(
 @_allow_symlinks_option
 @_write_signature_option
 @_private_key_option
+@_tsa_url_option
 @click.option(
     "--password",
     type=str,
@@ -468,6 +477,7 @@ def _sign_private_key(
     signature: pathlib.Path,
     private_key: pathlib.Path,
     password: str | None = None,
+    tsa_url: str | None = None,
 ) -> None:
     """Sign using a private key (paired with a public one).
 
@@ -487,7 +497,7 @@ def _sign_private_key(
             model_path, list(ignore_paths) + [signature]
         )
         model_signing.signing.Config().use_elliptic_key_signer(
-            private_key=private_key, password=password
+            private_key=private_key, password=password, tsa_url=tsa_url
         ).set_hashing_config(
             model_signing.hashing.Config()
             .set_ignored_paths(paths=ignored, ignore_git_paths=ignore_git_paths)
@@ -507,6 +517,7 @@ def _sign_private_key(
 @_allow_symlinks_option
 @_write_signature_option
 @_pkcs11_uri_option
+@_tsa_url_option
 def _sign_pkcs11_key(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
@@ -514,6 +525,7 @@ def _sign_pkcs11_key(
     allow_symlinks: bool,
     signature: pathlib.Path,
     pkcs11_uri: str,
+    tsa_url: str | None = None,
 ) -> None:
     """Sign using a private key using a PKCS #11 URI.
 
@@ -533,7 +545,7 @@ def _sign_pkcs11_key(
             model_path, list(ignore_paths) + [signature]
         )
         model_signing.signing.Config().use_pkcs11_signer(
-            pkcs11_uri=pkcs11_uri
+            pkcs11_uri=pkcs11_uri, tsa_url=tsa_url
         ).set_hashing_config(
             model_signing.hashing.Config()
             .set_ignored_paths(paths=ignored, ignore_git_paths=ignore_git_paths)
@@ -555,6 +567,7 @@ def _sign_pkcs11_key(
 @_private_key_option
 @_signing_certificate_option
 @_certificate_root_of_trust_option
+@_tsa_url_option
 def _sign_certificate(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
@@ -564,6 +577,7 @@ def _sign_certificate(
     private_key: pathlib.Path,
     signing_certificate: pathlib.Path,
     certificate_chain: Iterable[pathlib.Path],
+    tsa_url: str | None = None,
 ) -> None:
     """Sign using a certificate.
 
@@ -589,6 +603,7 @@ def _sign_certificate(
             private_key=private_key,
             signing_certificate=signing_certificate,
             certificate_chain=certificate_chain,
+            tsa_url=tsa_url,
         ).set_hashing_config(
             model_signing.hashing.Config()
             .set_ignored_paths(paths=ignored, ignore_git_paths=ignore_git_paths)
@@ -610,6 +625,7 @@ def _sign_certificate(
 @_pkcs11_uri_option
 @_signing_certificate_option
 @_certificate_root_of_trust_option
+@_tsa_url_option
 def _sign_pkcs11_certificate(
     model_path: pathlib.Path,
     ignore_paths: Iterable[pathlib.Path],
@@ -619,6 +635,7 @@ def _sign_pkcs11_certificate(
     pkcs11_uri: str,
     signing_certificate: pathlib.Path,
     certificate_chain: Iterable[pathlib.Path],
+    tsa_url: str | None = None,
 ) -> None:
     """Sign using a certificate.
 
@@ -645,6 +662,7 @@ def _sign_pkcs11_certificate(
             pkcs11_uri=pkcs11_uri,
             signing_certificate=signing_certificate,
             certificate_chain=certificate_chain,
+            tsa_url=tsa_url,
         ).set_hashing_config(
             model_signing.hashing.Config()
             .set_ignored_paths(paths=ignored, ignore_git_paths=ignore_git_paths)

--- a/src/model_signing/_signing/sign_certificate.py
+++ b/src/model_signing/_signing/sign_certificate.py
@@ -46,6 +46,7 @@ class Signer(ec_key.Signer):
         private_key_path: pathlib.Path,
         signing_certificate_path: pathlib.Path,
         certificate_chain_paths: Iterable[pathlib.Path],
+        tsa_url: str | None = None,
     ):
         """Initializes the signer with the key, certificate and trust chain.
 
@@ -54,12 +55,13 @@ class Signer(ec_key.Signer):
             signing_certificate_path: The path to the signing certificate.
             certificate_chain_paths: Paths to other certificates used to
               establish chain of trust.
+            tsa_url: Optional URL of an RFC 3161 Timestamp Authority.
 
         Raises:
             ValueError: Signing certificate's public key does not match the
               private key's public pair.
         """
-        super().__init__(private_key_path)
+        super().__init__(private_key_path, tsa_url=tsa_url)
         self._signing_certificate = x509.load_pem_x509_certificate(
             signing_certificate_path.read_bytes()
         )
@@ -196,6 +198,10 @@ class Verifier(sigstore_pb.Verifier):
         The public key is extracted from the signing certificate from the chain
         of trust, after the chain is validated. It must match the public key
         from the key used during signing.
+
+        If a TSA timestamp is present in the verification material, it will be
+        used as the verification time, allowing verification of signatures made
+        with certificates that have since expired.
         """
 
         def _to_openssl_certificate(certificate_bytes, log_fingerprints):
@@ -209,8 +215,15 @@ class Verifier(sigstore_pb.Verifier):
             signing_chain.certificates[0].raw_bytes
         )
 
-        max_signing_time = signing_certificate.not_valid_before_utc
-        self._store.set_time(max_signing_time)
+        tsa_timestamp = sigstore_pb.get_timestamp_from_bundle(
+            verification_material
+        )
+        if tsa_timestamp is not None:
+            verification_time = tsa_timestamp
+        else:
+            verification_time = signing_certificate.not_valid_before_utc
+
+        self._store.set_time(verification_time)
 
         trust_chain_ssl = [
             _to_openssl_certificate(

--- a/src/model_signing/_signing/sign_ec_key.py
+++ b/src/model_signing/_signing/sign_ec_key.py
@@ -86,18 +86,23 @@ class Signer(sigstore_pb.Signer):
     """Signer using an elliptic curve private key."""
 
     def __init__(
-        self, private_key_path: pathlib.Path, password: str | None = None
+        self,
+        private_key_path: pathlib.Path,
+        password: str | None = None,
+        tsa_url: str | None = None,
     ):
         """Initializes the signer with the private key and optional password.
 
         Args:
             private_key_path: The path to the PEM encoded private key.
             password: Optional password for the private key.
+            tsa_url: Optional URL of an RFC 3161 Timestamp Authority.
         """
         self._private_key = serialization.load_pem_private_key(
             private_key_path.read_bytes(), password
         )
         _check_supported_ec_key(self._private_key.public_key())
+        self._tsa_url = tsa_url
 
     @override
     def sign(self, payload: signing.Payload) -> signing.Signature:
@@ -105,14 +110,13 @@ class Signer(sigstore_pb.Signer):
             "utf-8"
         )
 
+        signature_bytes = self._private_key.sign(
+            sigstore_pb.pae(raw_payload),
+            ec.ECDSA(get_ec_key_hash(self._private_key.public_key())),
+        )
+
         raw_signature = intoto_pb.Signature(
-            sig=base64.b64encode(
-                self._private_key.sign(
-                    sigstore_pb.pae(raw_payload),
-                    ec.ECDSA(get_ec_key_hash(self._private_key.public_key())),
-                )
-            ),
-            keyid="",
+            sig=base64.b64encode(signature_bytes), keyid=""
         )
 
         envelope = intoto_pb.Envelope(
@@ -121,10 +125,17 @@ class Signer(sigstore_pb.Signer):
             signatures=[raw_signature],
         )
 
+        verification_material = self._get_verification_material()
+
+        if self._tsa_url:
+            verification_material.timestamp_verification_data = (
+                sigstore_pb.request_timestamp(signature_bytes, self._tsa_url)
+            )
+
         return sigstore_pb.Signature(
             bundle_pb.Bundle(
                 media_type=sigstore_pb._BUNDLE_MEDIA_TYPE,
-                verification_material=self._get_verification_material(),
+                verification_material=verification_material,
                 dsse_envelope=envelope,
             )
         )

--- a/src/model_signing/_signing/sign_pkcs11.py
+++ b/src/model_signing/_signing/sign_pkcs11.py
@@ -81,9 +81,13 @@ class Signer(sigstore_pb.Signer):
     """Signer using PKCS #11 URIs with elliptic curves keys."""
 
     def __init__(
-        self, pkcs11_uri: str, module_paths: Iterable[str] = frozenset()
+        self,
+        pkcs11_uri: str,
+        module_paths: Iterable[str] = frozenset(),
+        tsa_url: str | None = None,
     ):
         self.session = None
+        self._tsa_url = tsa_url
 
         self.pkcs11_uri = Pkcs11URI()
         self.pkcs11_uri.parse(pkcs11_uri)
@@ -183,10 +187,17 @@ class Signer(sigstore_pb.Signer):
             signatures=[raw_signature],
         )
 
+        verification_material = self._get_verification_material()
+
+        if self._tsa_url:
+            verification_material.timestamp_verification_data = (
+                sigstore_pb.request_timestamp(sig, self._tsa_url)
+            )
+
         return sigstore_pb.Signature(
             bundle_pb.Bundle(
                 media_type=sigstore_pb._BUNDLE_MEDIA_TYPE,
-                verification_material=self._get_verification_material(),
+                verification_material=verification_material,
                 dsse_envelope=envelope,
             )
         )
@@ -217,6 +228,7 @@ class CertSigner(Signer):
         signing_certificate_path: pathlib.Path,
         certificate_chain_paths: Iterable[pathlib.Path],
         module_paths: Iterable[str] = frozenset(),
+        tsa_url: str | None = None,
     ):
         """Initializes the signer with the key, certificate and trust chain.
 
@@ -226,12 +238,13 @@ class CertSigner(Signer):
             certificate_chain_paths: Paths to other certificates used to
               establish chain of trust.
             module_paths: Paths to PKCS #11 modules to load.
+            tsa_url: Optional URL of an RFC 3161 Timestamp Authority.
 
         Raises:
             ValueError: Signing certificate's public key does not match the
               private key's public pair.
         """
-        super().__init__(pkcs11_uri, module_paths=module_paths)
+        super().__init__(pkcs11_uri, module_paths=module_paths, tsa_url=tsa_url)
         self._signing_certificate = x509.load_pem_x509_certificate(
             signing_certificate_path.read_bytes()
         )

--- a/src/model_signing/_signing/sign_sigstore_pb.py
+++ b/src/model_signing/_signing/sign_sigstore_pb.py
@@ -22,15 +22,64 @@ validation does not allow those.
 """
 
 import abc
+import base64
+from datetime import datetime
 import json
+import logging
 import pathlib
 import sys
 from typing import cast
+import urllib.error
+import urllib.request
 
+import rfc3161_client
 from sigstore_models.bundle import v1 as bundle_pb
 from typing_extensions import override
 
 from model_signing._signing import signing
+
+
+logger = logging.getLogger(__name__)
+
+
+_TSA_CLIENT_TIMEOUT: int = 5
+_USER_AGENT: str = "model-signing"
+
+
+def _request_timestamp(
+    url: str, signature: bytes
+) -> rfc3161_client.TimeStampResponse:
+    """Request a timestamp from a TSA for the given signature."""
+    try:
+        timestamp_request = (
+            rfc3161_client.TimestampRequestBuilder()
+            .hash_algorithm(rfc3161_client.base.HashAlgorithm.SHA256)
+            .data(signature)
+            .nonce(nonce=True)
+            .build()
+        )
+    except ValueError as error:
+        raise ValueError(f"invalid TSA request: {error}") from error
+
+    req = urllib.request.Request(
+        url,
+        data=timestamp_request.as_bytes(),
+        headers={
+            "Content-Type": "application/timestamp-query",
+            "User-Agent": _USER_AGENT,
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=_TSA_CLIENT_TIMEOUT) as resp:
+            response_bytes = resp.read()
+    except urllib.error.URLError as error:
+        raise ValueError(f"TSA request failed: {error}") from error
+
+    try:
+        return rfc3161_client.decode_timestamp_response(response_bytes)
+    except ValueError as error:
+        raise ValueError(f"invalid TSA response: {error}") from error
 
 
 if sys.version_info >= (3, 11):
@@ -163,3 +212,52 @@ class Verifier(signing.Verifier):
         Since the bundle is generated via proto, we need to do more checks to
         replace what `verify_dsse` from `sigstore_python` does.
         """
+
+
+def request_timestamp(
+    signature_bytes: bytes, tsa_url: str
+) -> bundle_pb.TimestampVerificationData:
+    """Requests a timestamp from a TSA and returns verification data.
+
+    Args:
+        signature_bytes: The signature bytes to timestamp.
+        tsa_url: The URL of the RFC 3161 Timestamp Authority.
+
+    Returns:
+        TimestampVerificationData to include in the bundle.
+    """
+    response = _request_timestamp(tsa_url, signature_bytes)
+
+    return bundle_pb.TimestampVerificationData(
+        rfc3161_timestamps=[
+            bundle_pb.RFC3161SignedTimestamp(
+                signed_timestamp=base64.b64encode(response.as_bytes())
+            )
+        ]
+    )
+
+
+def get_timestamp_from_bundle(
+    verification_material: bundle_pb.VerificationMaterial,
+) -> datetime | None:
+    """Extracts the timestamp from the bundle's verification material.
+
+    Args:
+        verification_material: The bundle's verification material.
+
+    Returns:
+        The timestamp datetime if present and valid, None otherwise.
+    """
+    ts_data = verification_material.timestamp_verification_data
+    if not ts_data or not ts_data.rfc3161_timestamps:
+        return None
+
+    ts = ts_data.rfc3161_timestamps[0]
+    try:
+        response = rfc3161_client.decode_timestamp_response(
+            base64.b64decode(ts.signed_timestamp)
+        )
+        return response.tst_info.gen_time
+    except (ValueError, KeyError) as error:
+        logger.warning(f"Failed to decode timestamp from bundle: {error}")
+        return None

--- a/src/model_signing/signing.py
+++ b/src/model_signing/signing.py
@@ -187,7 +187,11 @@ class Config:
         return self
 
     def use_elliptic_key_signer(
-        self, *, private_key: hashing.PathLike, password: str | None = None
+        self,
+        *,
+        private_key: hashing.PathLike,
+        password: str | None = None,
+        tsa_url: str | None = None,
     ) -> Self:
         """Configures the signing to be performed using elliptic curve keys.
 
@@ -197,11 +201,15 @@ class Config:
         Args:
             private_key: The path to the private key to use for signing.
             password: An optional password for the key, if encrypted.
+            tsa_url: Optional URL of an RFC 3161 Timestamp Authority. When
+              provided, the signature will include a trusted timestamp.
 
         Return:
             The new signing configuration.
         """
-        self._signer = ec_key.Signer(pathlib.Path(private_key), password)
+        self._signer = ec_key.Signer(
+            pathlib.Path(private_key), password, tsa_url=tsa_url
+        )
         return self
 
     def use_certificate_signer(
@@ -210,6 +218,7 @@ class Config:
         private_key: hashing.PathLike,
         signing_certificate: hashing.PathLike,
         certificate_chain: Iterable[hashing.PathLike],
+        tsa_url: str | None = None,
     ) -> Self:
         """Configures the signing to be performed using signing certificates.
 
@@ -221,6 +230,8 @@ class Config:
             signing_certificate: The path to the signing certificate.
             certificate_chain: Optional paths to other certificates to establish
               a chain of trust.
+            tsa_url: Optional URL of an RFC 3161 Timestamp Authority. When
+              provided, the signature will include a trusted timestamp.
 
         Return:
             The new signing configuration.
@@ -229,11 +240,16 @@ class Config:
             pathlib.Path(private_key),
             pathlib.Path(signing_certificate),
             [pathlib.Path(c) for c in certificate_chain],
+            tsa_url=tsa_url,
         )
         return self
 
     def use_pkcs11_signer(
-        self, *, pkcs11_uri: str, module_paths: Iterable[str] = frozenset()
+        self,
+        *,
+        pkcs11_uri: str,
+        module_paths: Iterable[str] = frozenset(),
+        tsa_url: str | None = None,
     ) -> Self:
         """Configures the signing to be performed using PKCS #11.
 
@@ -243,6 +259,8 @@ class Config:
         Args:
             pkcs11_uri: The PKCS11 URI.
             module_paths: Optional list of paths of PKCS #11 modules.
+            tsa_url: Optional URL of an RFC 3161 Timestamp Authority. When
+              provided, the signature will include a trusted timestamp.
 
         Return:
             The new signing configuration.
@@ -254,7 +272,7 @@ class Config:
                 "PKCS #11 functionality requires the 'pkcs11' extra. "
                 "Install with 'pip install model-signing[pkcs11]'."
             ) from e
-        self._signer = pkcs11.Signer(pkcs11_uri, module_paths)
+        self._signer = pkcs11.Signer(pkcs11_uri, module_paths, tsa_url=tsa_url)
         return self
 
     def use_pkcs11_certificate_signer(
@@ -264,6 +282,7 @@ class Config:
         signing_certificate: pathlib.Path,
         certificate_chain: Iterable[pathlib.Path],
         module_paths: Iterable[str] = frozenset(),
+        tsa_url: str | None = None,
     ) -> Self:
         """Configures the signing to be performed using signing certificates.
 
@@ -276,6 +295,8 @@ class Config:
             certificate_chain: Optional paths to other certificates to establish
               a chain of trust.
             module_paths: Optional list of paths of PKCS #11 modules.
+            tsa_url: Optional URL of an RFC 3161 Timestamp Authority. When
+              provided, the signature will include a trusted timestamp.
 
         Return:
             The new signing configuration.
@@ -293,5 +314,6 @@ class Config:
             signing_certificate,
             certificate_chain,
             module_paths=module_paths,
+            tsa_url=tsa_url,
         )
         return self

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -429,3 +429,31 @@ class TestCertificateSigning:
             signature, ignore_git_paths, ["model.sig", "ignored"]
         )
         assert get_model_name(signature) == os.path.basename(model_path)
+
+
+class TestTSASigning:
+    @pytest.mark.integration
+    def test_sign_and_verify_with_tsa(self, base_path, populate_tmpdir):
+        os.chdir(base_path)
+
+        model_path = populate_tmpdir
+        signature = Path(model_path / "model.sig")
+        private_key = Path(TESTDATA / "keys/certificate/signing-key.pem")
+        public_key = Path(TESTDATA / "keys/certificate/signing-key-pub.pem")
+
+        signing.Config().use_elliptic_key_signer(
+            private_key=private_key,
+            tsa_url="https://timestamp.sigstore.dev/api/v1/timestamp",
+        ).set_hashing_config(
+            hashing.Config().set_ignored_paths(
+                paths=[signature], ignore_git_paths=False
+            )
+        ).sign(model_path, signature)
+
+        verifying.Config().use_elliptic_key_verifier(
+            public_key=public_key
+        ).set_hashing_config(
+            hashing.Config().set_ignored_paths(
+                paths=[signature], ignore_git_paths=False
+            )
+        ).verify(model_path, signature)


### PR DESCRIPTION
#### Summary

Add optional --tsa-url flag to key, certificate, pkcs11-key, and pkcs11-certificate signing commands. When provided, the signature bundle includes a trusted timestamp from the specified TSA.

The verifier uses the TSA timestamp (when present) to validate certificate chains, enabling signature verification even after the signing certificate has expired - as long as the signature was created while the certificate was valid.

- Add request_timestamp() and get_timestamp_from_bundle() to sign_sigstore_pb.py
- Update all PKI signers to accept tsa_url parameter
- Update certificate verifier to use TSA timestamp for validation
- Add --tsa-url CLI option to all PKI signing commands
- Update README and CHANGELOG with documentation

Closes #603 
<!-- Thanks for opening a pull request! Please do not just delete this text. -->
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code has docstrings and type annotations
- [x] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [x] Public facing changes are paired with documentation changes
- [x] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
