### PR TITLE
fix: scope hatch packages directive to wheel target only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All versions prior to 1.0.0 are untracked.
 - Standardized CLI flags to use hyphens (e.g., `--trust-config` instead of `--trust_config`). Underscore variants are still accepted for backwards compatibility via token normalization.
 
 ### Fixed
+- Fixed a bug where installing from the sdist produced an empty wheel with zero Python modules. The hatch `packages` directive was scoped to all build targets instead of the wheel target only, causing the sdist's flattened layout to not match the expected `src/` path. ([#636](https://github.com/sigstore/model-transparency/issues/636))
 - Fixed a bug where ignored symlinks could raise `ValueError`s if allow_symlinks was unset, even though they were skipped during serialization. ([#550](https://github.com/sigstore/model-transparency/pull/550))
 - Fixed a bug where any PEM encoded key could be read during the key-based flows which resulted in a Python exception because the rest of the code only supported elliptic curve keys. ([#573](https://github.com/sigstore/model-transparency/pull/573))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ PyPI = "https://pypi.org/project/model-signing/"
 [tool.hatch.version]
 path = "src/model_signing/__init__.py"
 
-[tool.hatch.build]
+[tool.hatch.build.targets.wheel]
 packages = ["src/model_signing"]
 
 [tool.hatch.envs.hatch-test]


### PR DESCRIPTION
The packages directive was under `[tool.hatch.build]` (general), which applies to both wheel and sdist targets. Hatchling's sdist builder flattens the src-layout, placing model_signing/ at the archive root, but the embedded pyproject.toml still references src/model_signing - a path that no longer exists in the sdist. This causes pip to install an empty wheel with zero Python modules.

Moving the directive to `[tool.hatch.build.targets.wheel]` lets the sdist target use hatchling's default behavior (preserve the full source tree including the src/ prefix), so the packages path matches the actual layout when installing from source distributions.

Resolves: #636

<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

This allows installation from sdist. I've tested with a script:
`test-sdist.sh`
```bash
#!/bin/bash
# Test whether rh-model-signing installs correctly from sdist.
# Usage: ./test-sdist.sh <branch>
set -euo pipefail

branch=${1}

git checkout "$branch" --quiet
rm -rf dist/ .venv-sdist-test
hatch build -t sdist
python -m venv .venv-sdist-test
.venv-sdist-test/bin/pip install dist/*.tar.gz --no-cache-dir --quiet
.venv-sdist-test/bin/python -c "import model_signing; print('PASS')"
rm -rf dist/ .venv-sdist-test
```
This fails on the current `main` (https://github.com/sigstore/model-transparency/commit/7643e29333d1eb993115074a18467165ca09e80a):

```
$ ./test-sdist.sh main
──────────────────────────────────────────────────────────────────────────────────────────── sdist ─────────────────────────────────────────────────────────────────────────────────────────────
dist/model_signing-1.1.1.tar.gz

Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import model_signing; print('PASS')
    ^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'model_signing'
```

But is fixed on this branch:
```
$ ./test-sdist.sh fix/sdist-build-config-sigstore
──────────────────────────────────────────────────────────────────────────────────────────── sdist ─────────────────────────────────────────────────────────────────────────────────────────────
dist/model_signing-1.1.1.tar.gz

PASS
```



##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code has docstrings and type annotations
- [x] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [x] Public facing changes are paired with documentation changes
- [x] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
