### PR TITLE
tests: Use new testing identity token source

### DIFF
--- a/.github/workflows/cross_os.yml
+++ b/.github/workflows/cross_os.yml
@@ -74,10 +74,12 @@ jobs:
           path: model_root/
       - name: Set up Hatch
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc # install
-      - name: store beacon token into oidc-token.txt
-        uses: sigstore-conformance/extremely-dangerous-public-oidc-beacon@977e8d08554ca9bda279c96e91be2119fb67c730 # main
+      - name: Fetch OIDC token
+        run: |
+          SIGSTORE_ID_TOKEN=$(curl -sSfL https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt)
+          echo "SIGSTORE_ID_TOKEN=$SIGSTORE_ID_TOKEN" >> "$GITHUB_ENV"
       - name: Sign the model
-        run: hatch run python -m model_signing sign sigstore model_root/ --use_staging --signature model.sig --identity_token $(cat oidc-token.txt)
+        run: hatch run python -m model_signing sign sigstore model_root/ --use_staging --signature model.sig --identity_token "${SIGSTORE_ID_TOKEN}"
       - name: upload model signature
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -113,5 +115,5 @@ jobs:
       - name: Verify the model
         run: |
           hatch run python -m model_signing verify sigstore model_root/ --use_staging --signature model.sig \
-            --identity "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main" \
-            --identity_provider "https://token.actions.githubusercontent.com"
+            --identity "untrusted-sa@sigstore-conformance.iam.gserviceaccount.com" \
+            --identity_provider "https://accounts.google.com"

--- a/scripts/tests/test-sign-verify-allversions.sh
+++ b/scripts/tests/test-sign-verify-allversions.sh
@@ -22,10 +22,6 @@ sigfile_key="${TMPDIR}/model.sig-key"
 sigfile_certificate="${TMPDIR}/model.sig-certificate"
 sigfile_sigstore="${TMPDIR}/model.sig-sigstore"
 
-TOKENPROJ="${TMPDIR}/tokenproj"
-mkdir -p "${TOKENPROJ}" || exit 1
-token_file="${TOKENPROJ}/oidc-token.txt"
-
 VENV="${TMPDIR}/venv"
 
 
@@ -68,15 +64,7 @@ if ! python -m model_signing \
 fi
 
 echo "Getting OIDC test-token for sigstore signing"
-if ! out=$(git clone \
-	--single-branch \
-	--branch current-token \
-	--depth 1 \
-	https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon \
-	"${TOKENPROJ}" 2>&1);
-then
-	echo "git clone failed"
-	echo "${out}"
+if ! id_token=$(curl -sSfL https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt); then
 	exit 1
 fi
 
@@ -84,7 +72,7 @@ echo "Signing with 'sigstore' method"
 if ! python -m model_signing \
 	sign sigstore \
 	--signature "${sigfile_sigstore}" \
-	--identity_token "$(cat "${token_file}")" \
+	--identity_token "${id_token}" \
 	--ignore-paths "${ignorefile}" \
 	"${MODELDIR}" || \
   test ! -f ${sigfile_sigstore}; then
@@ -169,8 +157,8 @@ for version in v1.0.1 v1.0.0 v0.3.1 v0.3.0; do
 	if ! out=$(python -m model_signing \
 		verify sigstore \
 		--signature "${sigfile_sigstore}" \
-		--identity https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main \
-		--identity_provider https://token.actions.githubusercontent.com \
+		--identity untrusted-sa@sigstore-conformance.iam.gserviceaccount.com \
+		--identity_provider https://accounts.google.com \
 		--ignore-paths "${ignorefile}" \
 		"${MODELDIR}" 2>&1); then
 		echo "Error: 'verify sigstore' failed with ${version}"

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import subprocess
 from tempfile import TemporaryDirectory
 import time
+import urllib.request
 
 import pytest
 
@@ -104,22 +105,9 @@ class DangerousPublicOIDCBeacon:
         self._token = ""
 
     def _fetch(self) -> None:
-        # the git approach is apparently fresher than https://raw.githubusercontent.com
-        # https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/issues/17
-        git_url = "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon.git"
-        with TemporaryDirectory() as tmpdir:
-            base_cmd = [
-                "git",
-                "clone",
-                "--quiet",
-                "--single-branch",
-                "--branch=current-token",
-                "--depth=1",
-            ]
-            subprocess.run(base_cmd + [git_url, tmpdir], check=True)
-            token_path = os.path.join(tmpdir, "oidc-token.txt")
-            with open(token_path) as f:
-                self._token = f.read().rstrip()
+        url = "https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt"
+        with urllib.request.urlopen(url) as response:
+            self._token = response.read().decode("utf-8").rstrip()
 
     def _expiration(self) -> datetime:
         payload = self._token.split(".")[1]
@@ -157,8 +145,8 @@ class TestSigstoreSigning:
         signature_path = tmp_path / "model.sig"
         sc.sign(sample_model_folder, signature_path)
 
-        expected_identity = "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main"
-        expected_oidc_issuer = "https://token.actions.githubusercontent.com"
+        expected_identity = "untrusted-sa@sigstore-conformance.iam.gserviceaccount.com"
+        expected_oidc_issuer = "https://accounts.google.com"
         verifying.Config().use_sigstore_verifier(
             identity=expected_identity,
             oidc_issuer=expected_oidc_issuer,
@@ -202,8 +190,8 @@ class TestSigstoreSigning:
         signature_path = tmp_path / "model.sig"
         sc.sign(sample_model_folder, signature_path)
 
-        expected_identity = "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main"
-        expected_oidc_issuer = "https://token.actions.githubusercontent.com"
+        expected_identity = "untrusted-sa@sigstore-conformance.iam.gserviceaccount.com"
+        expected_oidc_issuer = "https://accounts.google.com"
         verifying.Config().use_sigstore_verifier(
             identity=expected_identity,
             oidc_issuer=expected_oidc_issuer,


### PR DESCRIPTION
* New testing token is more reliably available and has a longer time-to-live
* Old token source will be deprecated later

See https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/pull/64 for context. This PR was partially machine generated.