### PR TITLE
feat: Add in-memory signing API returning the Sigstore bundle as bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All versions prior to 1.0.0 are untracked.
 ### Added
 - Added the `digest` subcommand to compute and print a model's digest. This enables other tools to easily pair the attestations with a model directory.
 - Added `--module-paths` option to PKCS #11 signing methods pkcs11-key and pkcs11-certificate.
+- Added `model_signing.signing.Config.sign_to_bytes()` (and a module-level `model_signing.signing.sign_to_bytes()` helper) that return the Sigstore bundle in memory as bytes instead of writing it to disk. This supports serverless and pipeline callers that need to stream or store the signature without filesystem access. ([#582](https://github.com/sigstore/model-transparency/issues/582))
 
 ### Changed
 - Standardized CLI flags to use hyphens (e.g., `--trust-config` instead of `--trust_config`). Underscore variants are still accepted for backwards compatibility via token normalization.

--- a/README.md
+++ b/README.md
@@ -372,6 +372,20 @@ for model in all_models:
     signing_config.sign(model, f"{model}_sharded.sig")
 ```
 
+To obtain the signature in memory instead of writing it to disk -- for example
+in a serverless function or a streaming pipeline that needs to push the bundle
+to an object store -- use `sign_to_bytes`, which returns the Sigstore bundle as
+bytes:
+
+```python
+import model_signing
+
+signature_bytes = model_signing.signing.sign_to_bytes("bert-base-uncased")
+```
+
+The same is available on an explicit configuration via
+`Config().sign_to_bytes(model)`.
+
 Verification needs a configuration. To verify using Sigstore:
 
 ```python

--- a/src/model_signing/_signing/sign_sigstore.py
+++ b/src/model_signing/_signing/sign_sigstore.py
@@ -51,7 +51,11 @@ class Signature(signing.Signature):
 
     @override
     def write(self, path: pathlib.Path) -> None:
-        path.write_text(self.bundle.to_json(), encoding="utf-8")
+        path.write_bytes(self.to_bytes())
+
+    @override
+    def to_bytes(self) -> bytes:
+        return self.bundle.to_json().encode("utf-8")
 
     @classmethod
     @override

--- a/src/model_signing/_signing/sign_sigstore_pb.py
+++ b/src/model_signing/_signing/sign_sigstore_pb.py
@@ -105,7 +105,11 @@ class Signature(signing.Signature):
 
     @override
     def write(self, path: pathlib.Path) -> None:
-        path.write_text(self.bundle.to_json(), encoding="utf-8")
+        path.write_bytes(self.to_bytes())
+
+    @override
+    def to_bytes(self) -> bytes:
+        return self.bundle.to_json().encode("utf-8")
 
     @classmethod
     @override

--- a/src/model_signing/_signing/signing.py
+++ b/src/model_signing/_signing/signing.py
@@ -304,6 +304,19 @@ class Signature(metaclass=abc.ABCMeta):
             path: The path to write the signature to.
         """
 
+    @abc.abstractmethod
+    def to_bytes(self) -> bytes:
+        """Serializes the signature to bytes.
+
+        Returns the same Sigstore bundle content that `write` persists to
+        disk, encoded as UTF-8 JSON. This lets callers in serverless or
+        pipeline contexts obtain the signature in memory without touching the
+        filesystem.
+
+        Returns:
+            The serialized signature, as UTF-8 encoded bytes.
+        """
+
     @classmethod
     @abc.abstractmethod
     def read(cls, path: pathlib.Path) -> Self:

--- a/src/model_signing/signing.py
+++ b/src/model_signing/signing.py
@@ -74,6 +74,24 @@ def sign(model_path: hashing.PathLike, signature_path: hashing.PathLike):
     Config().sign(model_path, signature_path)
 
 
+def sign_to_bytes(model_path: hashing.PathLike) -> bytes:
+    """Signs a model using the default configuration and returns the signature.
+
+    In this default configuration we sign using Sigstore and the default hashing
+    configuration from `model_signing.hashing`.
+
+    The resulting signature is the Sigstore bundle, returned in memory as UTF-8
+    encoded JSON bytes instead of being written to disk.
+
+    Args:
+        model_path: the path to the model to sign.
+
+    Returns:
+        The signature, as a Sigstore bundle encoded in UTF-8 JSON bytes.
+    """
+    return Config().sign_to_bytes(model_path)
+
+
 class Config:
     """Configuration to use when signing models.
 
@@ -101,12 +119,43 @@ class Config:
             model_path: The path to the model to sign.
             signature_path: The path of the resulting signature.
         """
+        signature = self._sign(model_path)
+        signature.write(pathlib.Path(signature_path))
+
+    def sign_to_bytes(self, model_path: hashing.PathLike) -> bytes:
+        """Signs a model and returns the signature as bytes.
+
+        This mirrors `sign`, but instead of writing the signature to disk it
+        returns the Sigstore bundle in memory. This is useful in serverless or
+        pipeline contexts where writing to the filesystem is undesirable or
+        impossible, and the bundle needs to be streamed, persisted to an object
+        store, or passed directly to another process.
+
+        The returned bytes are the UTF-8 encoded Sigstore bundle, identical to
+        what `sign` would have written to the signature path.
+
+        Args:
+            model_path: The path to the model to sign.
+
+        Returns:
+            The signature, as a Sigstore bundle encoded in UTF-8 JSON bytes.
+        """
+        return self._sign(model_path).to_bytes()
+
+    def _sign(self, model_path: hashing.PathLike) -> signing.Signature:
+        """Hashes and signs a model, returning the in-memory signature.
+
+        Args:
+            model_path: The path to the model to sign.
+
+        Returns:
+            The `Signature` produced by the configured signer.
+        """
         if self._signer is None:
             self.use_sigstore_signer()
         manifest = self._hashing_config.hash(model_path)
         payload = signing.Payload(manifest)
-        signature = self._signer.sign(payload)
-        signature.write(pathlib.Path(signature_path))
+        return self._signer.sign(payload)
 
     def set_hashing_config(self, hashing_config: hashing.Config) -> Self:
         """Sets the new configuration for hashing models.

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -218,6 +218,56 @@ class TestSigstoreSigning:
 
 
 class TestKeySigning:
+    def test_sign_to_bytes(self, base_path, populate_tmpdir):
+        os.chdir(base_path)
+
+        model_path = populate_tmpdir
+        signature = Path(model_path / "model.sig")
+        private_key = Path(TESTDATA / "keys/certificate/signing-key.pem")
+        public_key = Path(TESTDATA / "keys/certificate/signing-key-pub.pem")
+        hashing_config = hashing.Config().set_ignored_paths(
+            paths=[signature], ignore_git_paths=False
+        )
+
+        config = (
+            signing.Config()
+            .use_elliptic_key_signer(private_key=private_key)
+            .set_hashing_config(hashing_config)
+        )
+
+        # In-memory signing returns the Sigstore bundle as bytes, without
+        # writing anything to disk.
+        signature_bytes = config.sign_to_bytes(model_path)
+        assert isinstance(signature_bytes, bytes)
+        assert not signature.exists()
+
+        # The bytes are a valid Sigstore bundle carrying the expected payload.
+        bundle = json.loads(signature_bytes)
+        payload = json.loads(b64decode(bundle["dsseEnvelope"]["payload"]))
+        signed_files = [
+            entry["name"] for entry in payload["predicate"]["resources"]
+        ]
+        assert signed_files == [".gitignore", "signme-1", "signme-2"]
+
+        # The in-memory bundle is not just well-formed, it verifies: persist
+        # the bytes unmodified and run the normal verification path over them.
+        # `verify` raises on any failure, so reaching the next line is the
+        # assertion.
+        signature.write_bytes(signature_bytes)
+        verifying.Config().use_elliptic_key_verifier(
+            public_key=public_key
+        ).set_hashing_config(hashing_config).verify(model_path, signature)
+
+        # The in-memory payload matches what writing to disk produces. The
+        # bundle signature itself is non-deterministic (ECDSA), so we compare
+        # the signed DSSE payload rather than the raw bytes.
+        config.sign(model_path, signature)
+        disk_bundle = json.loads(signature.read_text())
+        disk_payload = json.loads(
+            b64decode(disk_bundle["dsseEnvelope"]["payload"])
+        )
+        assert payload == disk_payload
+
     def test_sign_and_verify(self, base_path, populate_tmpdir):
         os.chdir(base_path)
 


### PR DESCRIPTION
## Summary

Adds `Config.sign_to_bytes()` (and a module-level `signing.sign_to_bytes()` helper) so callers can obtain the Sigstore bundle in memory as bytes instead of being forced to write it to disk, enabling serverless and pipeline signing flows. The existing disk-writing `sign()` remains the default and is unchanged for callers. This is the library half of #582; the `--stdout` CLI flag also requested in that issue is a natural follow-up that builds directly on this API, so this PR is tagged `Part of: #582` rather than closing it.

## Problem

Today the only way to capture a signature through the library API is `Config.sign(model_path, signature_path)`, which serializes the bundle and writes it to a filesystem path. In serverless functions (read-only or ephemeral filesystems), CI/CD steps, and streaming pipelines, the caller wants the bundle bytes directly -- to push to an object store, attach to an HTTP response, or hand to another process -- without round-tripping through a temp file. The workaround (write to a temp file, read it back, delete it) adds filesystem dependencies, cleanup burden, and a small race/leak surface for what is sensitive signing output. This is the gap raised in #582 and requested by the maintainer.

## Change

Following the existing API conventions:

- `model_signing/_signing/signing.py`: added an abstract `to_bytes(self) -> bytes` method to the `Signature` base class, mirroring the existing `write`/`read` contract.
- `model_signing/_signing/sign_sigstore.py` and `sign_sigstore_pb.py`: implemented `to_bytes()` as `self.bundle.to_json().encode("utf-8")`, and refactored `write()` to delegate to it (`path.write_bytes(self.to_bytes())`) so the on-disk and in-memory representations are guaranteed identical and produced by a single code path. These are the only two concrete `Signature` subclasses; the elliptic-key and PKCS#11 signers both return `sign_sigstore_pb.Signature`, so no subclass is left without an implementation.
- `model_signing/signing.py`: extracted the hash -> payload -> sign sequence shared by both output modes into a private `_sign()` helper, then added `Config.sign_to_bytes(model_path) -> bytes` and a module-level `sign_to_bytes(model_path)` convenience function that mirrors the existing `sign()` function. `sign()` now reuses `_sign()` and is behaviorally unchanged.
- `README.md`: added a usage snippet for `sign_to_bytes()` in the Model Signing API section, alongside the existing `sign()` examples.
- `tests/api_test.py`: added `TestKeySigning::test_sign_to_bytes`. It asserts the returned value is `bytes`, that nothing is written to disk, that the bytes parse as a valid Sigstore bundle with the expected signed resources, that persisting those bytes unmodified and running them through the normal elliptic-key verification path succeeds, and that the in-memory DSSE payload is identical to what `sign()` writes to disk.
- `CHANGELOG.md`: added an entry under `Unreleased / Added`.

The change is purely additive and backwards compatible -- no existing signature, default, or output is altered.

## Security rationale

The bundle returned by `to_bytes()` is byte-for-byte the same Sigstore bundle that `write()` persists -- both now flow through the single `to_bytes()` serializer, so there is no divergence between the in-memory and on-disk signed artifact, and no second serialization path to audit. Keeping signing output in memory removes an unnecessary plaintext-on-disk step for sensitive provenance material, which is desirable on shared or ephemeral build hosts and reduces residual-file cleanup obligations (cf. CWE-459 Incomplete Cleanup, CWE-212 Improper Removal of Sensitive Information, CWE-200). This strengthens ML supply-chain integrity -- the project's core purpose, aligned with SLSA provenance and OWASP ML Security Top 10 ML06 (AI Supply Chain Attacks) -- by making it practical to sign in environments that previously could not write to disk, rather than encouraging the insecure write-read-delete workaround. No new key material handling, network behavior, or trust decision is introduced; the signer, payload, and bundle format are unchanged.

## Testing

Rebased onto `main` at 6210542 and re-verified locally with the project's own hatch invocations (the ones `unit_tests.yml` and `lint.yml` use):

- `hatch test -c -py 3.12` -- `201 passed`, 84% total coverage. Same suite on unmodified `main` is `200 passed`, so this adds exactly one test and breaks none.
- `hatch test -c -py 3.10` and `hatch test -c -py 3.14` -- `201 passed` on each.
- `hatch fmt --check` -- `ruff check src/`: `All checks passed!`; `ruff format --check src/`: `23 files already formatted`.
- I could not run `hatch run type:check` (pytype) locally -- it dies with `/bin/sh: /Users/.../Library/Application: No such file or directory` because my hatch env path contains a space. That is a local environment problem, not a code one, and CI covers it.

To confirm the round-trip assertion is not decorative, I mutated `to_bytes()` in `sign_sigstore_pb.py` to emit a bundle that is still valid JSON with an identical DSSE payload but a corrupted `dsseEnvelope.signatures[0].sig`. The strengthened test fails on it (`cryptography.exceptions.InvalidSignature`); without the verification step it passes. So the test now catches a `to_bytes()` that produces well-formed but cryptographically invalid output, not just a well-formed one.

The new test uses local elliptic-key signing, so it runs offline with no Sigstore/OIDC network dependency. Because the elliptic-key signer returns `sign_sigstore_pb.Signature`, this offline test also exercises the new `to_bytes()` implementation directly.

Part of: #582

##### Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code has docstrings and type annotations
- [x] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [x] Public facing changes are paired with documentation changes
- [x] Release note has been added to CHANGELOG.md if needed

