### PR TITLE
fix: reject empty models during signing and verification

### DIFF
--- a/src/model_signing/_serialization/file.py
+++ b/src/model_signing/_serialization/file.py
@@ -118,6 +118,11 @@ class Serializer(serialization.Serializer):
             if path.is_file():
                 paths.append(path)
 
+        if not paths:
+            raise ValueError(
+                "Model contains no regular files after applying exclusions"
+            )
+
         manifest_items = []
         with concurrent.futures.ThreadPoolExecutor(
             # blake3 parallelizes internally

--- a/src/model_signing/_serialization/file_shard.py
+++ b/src/model_signing/_serialization/file_shard.py
@@ -135,6 +135,7 @@ class Serializer(serialization.Serializer):
               was not initialized with `allow_symlinks=True`.
         """
         shards = []
+        file_count = 0
         # TODO: github.com/sigstore/model-transparency/issues/200 - When
         # Python3.12 is the minimum supported version, the glob can be replaced
         # with `pathlib.Path.walk` for a clearer interface, and some speed
@@ -150,7 +151,18 @@ class Serializer(serialization.Serializer):
                 path, allow_symlinks=self._allow_symlinks
             )
             if path.is_file():
+                file_count += 1
                 shards.extend(self._get_shards(path))
+
+        if file_count == 0:
+            raise ValueError(
+                "Model contains no regular files after applying exclusions"
+            )
+
+        if not shards:
+            raise ValueError(
+                "Model contains only empty files which produce no shards"
+            )
 
         manifest_items = []
         with concurrent.futures.ThreadPoolExecutor(

--- a/src/model_signing/_signing/signing.py
+++ b/src/model_signing/_signing/signing.py
@@ -103,12 +103,16 @@ def dsse_payload_to_manifest(dsse_payload: dict[str, Any]) -> manifest.Manifest:
     expected_digest = subjects[0]["digest"]["sha256"]
 
     predicate = dsse_payload["predicate"]
+    resources = predicate["resources"]
+    if not resources:
+        raise ValueError("Bundle contains no resources")
+
     serialization_args = predicate["serialization"]
     serialization = manifest.SerializationType.from_args(serialization_args)
 
     hasher = memory.SHA256()
     items = []
-    for resource in predicate["resources"]:
+    for resource in resources:
         name = resource["name"]
         algorithm = resource["algorithm"]
         digest_value = resource["digest"]

--- a/tests/_serialization/file_shard_test.py
+++ b/tests/_serialization/file_shard_test.py
@@ -74,7 +74,16 @@ class TestSerializer:
             path, memory.SHA256(), start=start, end=end, shard_size=8
         )
 
-    @pytest.mark.parametrize("model_fixture_name", test_support.all_test_models)
+    def test_empty_model_folder_rejected(self, empty_model_folder):
+        serializer = file_shard.Serializer(
+            self._hasher_factory, allow_symlinks=True
+        )
+        with pytest.raises(ValueError, match="no regular files"):
+            serializer.serialize(empty_model_folder)
+
+    @pytest.mark.parametrize(
+        "model_fixture_name", test_support.all_shardable_test_models
+    )
     def test_known_models(self, request, model_fixture_name):
         # Set up variables (arrange)
         testdata_path = request.path.parent / "testdata"
@@ -105,7 +114,9 @@ class TestSerializer:
 
             assert items == found_items
 
-    @pytest.mark.parametrize("model_fixture_name", test_support.all_test_models)
+    @pytest.mark.parametrize(
+        "model_fixture_name", test_support.all_shardable_test_models
+    )
     def test_known_models_small_shards(self, request, model_fixture_name):
         # Set up variables (arrange)
         testdata_path = request.path.parent / "testdata"
@@ -388,8 +399,10 @@ class TestSerializer:
         assert manifest1 != manifest2
         assert len(manifest1._item_to_digest) > len(manifest2._item_to_digest)
 
-    def test_ignored_symlinks_dont_raise_error(self, symlink_model_folder):
+    def test_ignored_symlinks_rejects_empty_model(self, symlink_model_folder):
+        symlink_path = symlink_model_folder / "symlink_file"
         serializer = file_shard.Serializer(self._hasher_factory)
-        _ = serializer.serialize(
-            symlink_model_folder, ignore_paths=[symlink_model_folder]
-        )
+        with pytest.raises(ValueError, match="no regular files"):
+            serializer.serialize(
+                symlink_model_folder, ignore_paths=[symlink_path]
+            )

--- a/tests/_serialization/file_test.py
+++ b/tests/_serialization/file_test.py
@@ -38,7 +38,14 @@ class TestSerializer:
     def _hasher_factory(self, path: pathlib.Path) -> io.FileHasher:
         return io.SimpleFileHasher(path, memory.SHA256())
 
-    @pytest.mark.parametrize("model_fixture_name", test_support.all_test_models)
+    def test_empty_model_folder_rejected(self, empty_model_folder):
+        serializer = file.Serializer(self._hasher_factory, allow_symlinks=True)
+        with pytest.raises(ValueError, match="no regular files"):
+            serializer.serialize(empty_model_folder)
+
+    @pytest.mark.parametrize(
+        "model_fixture_name", test_support.all_non_empty_test_models
+    )
     def test_known_models(self, request, model_fixture_name):
         # Set up variables (arrange)
         testdata_path = request.path.parent / "testdata"
@@ -320,11 +327,13 @@ class TestSerializer:
         diff = len(manifest1._item_to_digest) - len(manifest2._item_to_digest)
         assert diff == ignored_file_count
 
-    def test_ignored_symlinks_dont_raise_error(self, symlink_model_folder):
+    def test_ignored_symlinks_rejects_empty_model(self, symlink_model_folder):
+        symlink_path = symlink_model_folder / "symlink_file"
         serializer = file.Serializer(self._hasher_factory)
-        _ = serializer.serialize(
-            symlink_model_folder, ignore_paths=[symlink_model_folder]
-        )
+        with pytest.raises(ValueError, match="no regular files"):
+            serializer.serialize(
+                symlink_model_folder, ignore_paths=[symlink_path]
+            )
 
 
 class TestUtilities:

--- a/tests/_signing/signing_test.py
+++ b/tests/_signing/signing_test.py
@@ -75,7 +75,9 @@ class TestPayload:
 
             assert payload.statement.pb == expected_proto
 
-    @pytest.mark.parametrize("model_fixture_name", test_support.all_test_models)
+    @pytest.mark.parametrize(
+        "model_fixture_name", test_support.all_non_empty_test_models
+    )
     def test_known_models_file(self, request, model_fixture_name):
         self._run_test(
             request.path.parent / "testdata",
@@ -85,7 +87,9 @@ class TestPayload:
             file.Serializer(self._file_hasher_factory, allow_symlinks=True),
         )
 
-    @pytest.mark.parametrize("model_fixture_name", test_support.all_test_models)
+    @pytest.mark.parametrize(
+        "model_fixture_name", test_support.all_shardable_test_models
+    )
     def test_known_models_shard(self, request, model_fixture_name):
         self._run_test(
             request.path.parent / "testdata",
@@ -97,7 +101,9 @@ class TestPayload:
             ),
         )
 
-    @pytest.mark.parametrize("model_fixture_name", test_support.all_test_models)
+    @pytest.mark.parametrize(
+        "model_fixture_name", test_support.all_shardable_test_models
+    )
     def test_known_models_small_shards(self, request, model_fixture_name):
         self._run_test(
             request.path.parent / "testdata",
@@ -109,7 +115,9 @@ class TestPayload:
             ),
         )
 
-    @pytest.mark.parametrize("model_fixture_name", test_support.all_test_models)
+    @pytest.mark.parametrize(
+        "model_fixture_name", test_support.all_non_empty_test_models
+    )
     def test_restore_manifest_file(self, request, model_fixture_name):
         model = request.getfixturevalue(model_fixture_name)
         serializer = file.Serializer(
@@ -126,7 +134,9 @@ class TestPayload:
         assert restored.model_name == manifest.model_name
         assert restored.serialization_type == manifest.serialization_type
 
-    @pytest.mark.parametrize("model_fixture_name", test_support.all_test_models)
+    @pytest.mark.parametrize(
+        "model_fixture_name", test_support.all_shardable_test_models
+    )
     def test_restore_manifest_shard(self, request, model_fixture_name):
         model = request.getfixturevalue(model_fixture_name)
         serializer = file_shard.Serializer(

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -53,6 +53,27 @@ all_non_empty_directory_test_models = [
     "symlink_model_folder",
 ]
 
+# Models with at least one regular file. Excludes empty directories
+# which are rejected per spec §6.1.
+all_non_empty_test_models = [
+    "sample_model_file",
+    "sample_model_folder",
+    "deep_model_folder",
+    "empty_model_file",
+    "model_folder_with_empty_file",
+    "symlink_model_folder",
+]
+
+# Models that produce at least one shard under shard serialization.
+# Excludes empty directories and models with only zero-byte files
+# (which produce no shards per spec §6.3.2).
+all_shardable_test_models = [
+    "sample_model_file",
+    "sample_model_folder",
+    "deep_model_folder",
+    "symlink_model_folder",
+]
+
 
 # All files models to use in testing, where only file models are supported.
 all_file_test_models = [


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->
  - Signing now rejects models with no regular files after applying exclusions, per OMS spec v1.0 §6.1 ("an empty model MUST be rejected") and §5.2.1 ("the resources array MUST contain at least one entry")
  - Shard serialization additionally rejects models containing only zero-byte files, which produce no shards per §6.3.2
  - Verification rejects bundles with an empty resources array, preventing previously-signed empty bundles from passing

Closes https://github.com/sigstore/model-transparency/issues/661

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
